### PR TITLE
Fix zoom binding

### DIFF
--- a/src/herald/viewherald.js
+++ b/src/herald/viewherald.js
@@ -3,6 +3,7 @@ goog.provide('olgm.herald.View');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('olgm');
 goog.require('olgm.herald.Herald');
 
 
@@ -89,9 +90,12 @@ olgm.herald.View.prototype.setCenter = function() {
  * Set the gmap map zoom level at the ol3 map view zoom level.
  */
 olgm.herald.View.prototype.setZoom = function() {
-  var zoom = this.ol3map.getView().getZoom();
-  if (goog.isNumber(zoom)) {
-    this.gmap.setZoom(zoom);
+  var resolution = this.ol3map.getView().getResolution();
+  if (goog.isNumber(resolution)) {
+    var zoom = olgm.getZoomFromResolution(resolution);
+    if (zoom !== null) {
+      this.gmap.setZoom(zoom);
+    }
   }
 };
 

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -4,6 +4,36 @@ goog.require('goog.events');
 
 
 /**
+ * @type {!Array.<number>}
+ */
+olgm.RESOLUTIONS = [
+  156543.03390625,
+  78271.516953125,
+  39135.7584765625,
+  19567.87923828125,
+  9783.939619140625,
+  4891.9698095703125,
+  2445.9849047851562,
+  1222.9924523925781,
+  611.4962261962891,
+  305.74811309814453,
+  152.87405654907226,
+  76.43702827453613,
+  38.218514137268066,
+  19.109257068634033,
+  9.554628534317017,
+  4.777314267158508,
+  2.388657133579254,
+  1.194328566789627,
+  0.5971642833948135,
+  0.298582141697,
+  0.14929107084,
+  0.07464553542,
+  0.03732276771
+];
+
+
+/**
  * @param {string|Array.<number>} color
  * @return {string}
  */
@@ -56,6 +86,27 @@ olgm.getColorOpacity = function(color) {
   }
 
   return opacity;
+};
+
+
+/**
+ * @param {number} resolution
+ * @return {?number}
+ */
+olgm.getZoomFromResolution = function(resolution) {
+
+  var found = null;
+  var precision = 1000;
+  var res = Math.round(resolution * precision) / precision;
+
+  for (var z = 0, len = olgm.RESOLUTIONS.length; z < len; z++) {
+    if (res == Math.round(olgm.RESOLUTIONS[z] * precision) / precision) {
+      found = z;
+      break;
+    }
+  }
+
+  return found;
 };
 
 


### PR DESCRIPTION
Support ol3 maps that have different zoom levels than those
defined in Google Map.
