### PR TITLE
Fix empty style

### DIFF
--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -261,5 +261,12 @@ olgm.gm.createStyleInternal = function(style) {
   }
   */
 
+  // if, at this very last point, there aren't any style options that have
+  // been set, then tell Google Maps to render the feature invisible because
+  // we're dealing with an empty `ol.style.Style` object.
+  if (Object.keys(/** @type {!Object} */ (gmStyle)).length === 0) {
+    gmStyle['visible'] = false;
+  }
+
   return gmStyle;
 };


### PR DESCRIPTION
It is valid to create an empty `ol.style.Style` object in ol3.
When parsing its properties, nothing is found (obviously, it's
empty), which resulted in giving an empty style options object
to Google Maps, which gets ignored. To fix that, the 'visible'
is set when the style options object is empty.
