### PR TITLE
Add getter to know if Google Maps is active

### DIFF
--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -143,6 +143,14 @@ olgm.herald.Layers.prototype.deactivate = function() {
 
 
 /**
+ * @return {boolean}
+ */
+olgm.herald.Layers.prototype.getGoogleMapsActive = function() {
+  return this.googleMapsIsActive_;
+};
+
+
+/**
  * Callback method fired when a new layer is added to the map.
  * @param {ol.CollectionEvent} event Collection event.
  * @private

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -64,9 +64,12 @@ olgm.OLGoogleMaps = function(options) {
 
   goog.base(this, options.map, gmap);
 
-  // create the heralds required at the map level, i.e. for components inside
-  // the ol3 map.
-  this.heralds_.push(new olgm.herald.Layers(this.ol3map, this.gmap));
+  /**
+   * @type {olgm.herald.Layers}
+   * @private
+   */
+  this.layersHerald_ = new olgm.herald.Layers(this.ol3map, this.gmap);
+  this.heralds_.push(this.layersHerald_);
 };
 goog.inherits(olgm.OLGoogleMaps, olgm.Abstract);
 
@@ -111,6 +114,15 @@ olgm.OLGoogleMaps.prototype.deactivate = function() {
   }
 
   this.active_ = false;
+};
+
+
+/**
+ * @return {boolean}
+ * @api
+ */
+olgm.OLGoogleMaps.prototype.getGoogleMapsActive = function() {
+  return this.active_ && this.layersHerald_.getGoogleMapsActive();
 };
 
 


### PR DESCRIPTION
This patch introduces a getter method that allows to know if the
Google Maps map is active or not.  Google Maps is active if the
library is active AND if at least one visible Google layer is in
the ol3 map.
