### PR TITLE
Support vector labels (text styling)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,3 +20,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+Portions of this library were borrowed from the MapLabel project, which
+original source code is available at
+
+    http://google-maps-utility-library-v3.googlecode.com/svn/trunk/maplabel
+
+and published under the following license:
+
+Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -72,10 +72,34 @@ map options, in which the interations that allow rotating the map are not
 included.
 
 
+Vector features
+---------------
+
+Google Maps API uses several layers to render its vector features. They are
+known a
+[MapPanes](https://developers.google.com/maps/documentation/javascript/reference#MapPanes),
+each having a fixed Z order.  Polygons and Linestrings are rendered in the
+`overlayLayer` (Pane 1). Points are rendered in the `markerLayer` (Pane 2).
+
+This means that the Z order defined in OpenLayers is not exactly the same
+in Google Maps.
+
+
+
 Vector labels (text)
 --------------------
 
-Vector labels are not yet supported by this library.  They should be in the
-next release.
+Vector labels, i.e. text styling definition, are supported but come with
+several limitations. Before jumping into those, note that OL3-Google-Maps
+focuses on having the labels on the Z order they are added, i.e. a polygon
+added after a label should be rendered on top of the text.
 
-Recommendation: stay tuned, they are coming soon!
+Limitations:
+
+ * the `rotation` option is currently not supported
+ * in the Google Maps map, the labels are rendered in the `markerLayer`
+   (Pane 2), which makes the Z order of labels not working as expected
+   for polygons and linestring
+ * in Google Maps, markers that use image as source are rendered in tiles,
+   which ignore the Z order defined per feature. This causes the labels
+   to always appear on top of all markers.

--- a/examples/label.html
+++ b/examples/label.html
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps label example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Label example</h4>
+          <p>
+            Demonstrates the support of map labels, i.e. vector text on
+            the map.
+          </p>
+          <p>
+            The MapLabel library, which is natively included in
+            OL3-Google-Maps, takes care of rendering the text labels in
+            Google Maps.
+          </p>
+
+          <input id="toggle" type="button" onclick="toggle();"
+                 value="Toggle Between OL3 and GMAPS" />
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../ol3/build/ol.js"></script>
+
+    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+
+    <script src="/@loader"></script>
+    <script src="label.js"></script>
+  </body>
+</html>

--- a/examples/label.js
+++ b/examples/label.js
@@ -1,0 +1,102 @@
+var center = [-7908084, 6177492];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var source = new ol.source.Vector();
+var feature = new ol.Feature(new ol.geom.Point(center));
+feature.setStyle(new ol.style.Style({
+    image: new ol.style.Circle({
+      'fill': new ol.style.Fill({color: 'rgba(153,51,51,1)'}),
+      'stroke': new ol.style.Stroke({color: 'rgb(30,30,30)', width: 2}),
+      'radius': 20
+    }),
+    text: new ol.style.Text({
+      font: 'normal 12pt Arial',
+      text: '930',
+      fill: new ol.style.Fill({color: 'black'}),
+      stroke: new ol.style.Stroke({color: 'white', width: 3})
+    })
+  }));
+
+var feature2 = new ol.Feature(new ol.geom.Point([-7907700, 6176600]));
+feature2.setStyle(new ol.style.Style({
+    image: new ol.style.Circle({
+      'fill': new ol.style.Fill({color: 'rgba(51,153,51,1)'}),
+      'stroke': new ol.style.Stroke({color: 'rgb(30,30,30)', width: 2}),
+      'radius': 20
+    }),
+    text: new ol.style.Text({
+      font: 'normal 18pt Arial',
+      text: 'Hi',
+      fill: new ol.style.Fill({color: 'black'}),
+      stroke: new ol.style.Stroke({color: 'white', width: 3})
+    })
+  }));
+
+var feature3 = new ol.Feature(ol.geom.Polygon.fromExtent(
+    [-7920319, 6176097, -7914143, 6179053]));
+
+feature3.setStyle(new ol.style.Style({
+  fill: new ol.style.Fill({color: 'rgba(51,153,51,1)'}),
+  stroke: new ol.style.Stroke({color: 'rgb(30,30,30)', width: 2}),
+  text: new ol.style.Text({
+    textAlign: 'left',
+    textBaseline: 'bottom',
+    font: 'normal 10pt Arial',
+    text: 'Bottom-Left',
+    fill: new ol.style.Fill({color: 'black'}),
+    stroke: new ol.style.Stroke({color: 'white', width: 3})
+  })
+}));
+
+var marker = new ol.Feature(new ol.geom.Point([-7912700, 6176500]));
+marker.setStyle(new ol.style.Style({
+    image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+      anchor: [0.5, 46],
+      anchorXUnits: 'fraction',
+      anchorYUnits: 'pixels',
+      src: 'data/icon.png'
+    })),
+    text: new ol.style.Text({
+      offsetX: 0,
+      offsetY: -32,
+      font: 'normal 20pt Courrier',
+      text: 'X',
+      fill: new ol.style.Fill({color: 'black'}),
+      stroke: new ol.style.Stroke({color: 'white', width: 4})
+    })
+  }));
+
+source.addFeatures([feature, feature2, feature3, marker]);
+var vector = new ol.layer.Vector({
+  source: source
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    vector
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 12
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+
+function toggle() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -1,0 +1,220 @@
+/**
+ * The following file was borrowed from the MapLabel project, which original
+ * source code is available at: 
+ *
+ *     http://google-maps-utility-library-v3.googlecode.com/svn/trunk/maplabel
+ *
+ * Here's a copy of its license:
+ *
+ * Copyright 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Map Label.
+ *
+ * @author lukem@google.com (Luke Mahe)
+ * @author cbro@google.com (Chris Broadfoot)
+ *
+ * Integration to OL3-Google-Maps:
+ * @author adube@mapgears.com (Alexandre Dubé)
+ */
+
+goog.provide('olgm.gm.MapLabel');
+
+
+
+/**
+ * Creates a new Map Label
+ * @constructor
+ * @extends {google.maps.OverlayView}
+ * @param {Object.<string, *>=} opt_options Optional properties to set.
+ * @api
+ */
+olgm.gm.MapLabel = function(opt_options) {
+  this.set('fontFamily', 'sans-serif');
+  this.set('fontSize', 12);
+  this.set('fontColor', '#000000');
+  this.set('strokeWeight', 4);
+  this.set('strokeColor', '#ffffff');
+  this.set('align', 'center');
+
+  this.set('zIndex', 1e3);
+
+  this.setValues(opt_options);
+};
+goog.inherits(olgm.gm.MapLabel, google.maps.OverlayView);
+
+
+/** @inheritDoc */
+olgm.gm.MapLabel.prototype.changed = function(prop) {
+  switch (prop) {
+    case 'fontFamily':
+    case 'fontSize':
+    case 'fontColor':
+    case 'strokeWeight':
+    case 'strokeColor':
+    case 'align':
+    case 'text':
+      return this.drawCanvas_();
+    case 'maxZoom':
+    case 'minZoom':
+    case 'position':
+      return this.draw();
+  }
+};
+
+
+/**
+ * Draws the label to the canvas 2d context.
+ * @private
+ */
+olgm.gm.MapLabel.prototype.drawCanvas_ = function() {
+  var canvas = this.canvas_;
+  if (!canvas) return;
+
+  var style = canvas.style;
+  style.zIndex = /** @type {number} */ (this.get('zIndex'));
+
+  var ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = this.get('strokeColor');
+  ctx.fillStyle = this.get('fontColor');
+  ctx.font = this.get('fontSize') + 'px ' + this.get('fontFamily');
+
+  var strokeWeight = Number(this.get('strokeWeight'));
+
+  var text = this.get('text');
+  if (text) {
+    if (strokeWeight) {
+      ctx.lineWidth = strokeWeight;
+      ctx.strokeText(text, strokeWeight, strokeWeight);
+    }
+
+    ctx.fillText(text, strokeWeight, strokeWeight);
+
+    var textMeasure = ctx.measureText(text);
+    var textWidth = textMeasure.width + strokeWeight;
+    style.marginLeft = this.getMarginLeft_(textWidth) + 'px';
+    // Bring actual text top in line with desired latitude.
+    // Cheaper than calculating height of text.
+    style.marginTop = '-0.4em';
+  }
+};
+
+
+/**
+ * @inheritDoc
+ */
+olgm.gm.MapLabel.prototype.onAdd = function() {
+  var canvas = this.canvas_ = document.createElement('canvas');
+  var style = canvas.style;
+  style.position = 'absolute';
+
+  var ctx = canvas.getContext('2d');
+  ctx.lineJoin = 'round';
+  ctx.textBaseline = 'top';
+
+  this.drawCanvas_();
+
+  var panes = this.getPanes();
+  if (panes) {
+    panes.mapPane.appendChild(canvas);
+  }
+};
+
+
+/**
+ * Gets the appropriate margin-left for the canvas.
+ * @private
+ * @param {number} textWidth  the width of the text, in pixels.
+ * @return {number} the margin-left, in pixels.
+ */
+olgm.gm.MapLabel.prototype.getMarginLeft_ = function(textWidth) {
+  switch (this.get('align')) {
+    case 'left':
+      return 0;
+    case 'right':
+      return -textWidth;
+  }
+  return textWidth / -2;
+};
+
+
+/**
+ * @inheritDoc
+ */
+olgm.gm.MapLabel.prototype.draw = function() {
+  var projection = this.getProjection();
+
+  if (!projection) {
+    // The map projection is not ready yet so do nothing
+    return;
+  }
+
+  if (!this.canvas_) {
+    // onAdd has not been called yet.
+    return;
+  }
+
+  var latLng = /** @type {google.maps.LatLng} */ (this.get('position'));
+  if (!latLng) {
+    return;
+  }
+  var pos = projection.fromLatLngToDivPixel(latLng);
+
+  var style = this.canvas_.style;
+
+  style['top'] = pos.y + 'px';
+  style['left'] = pos.x + 'px';
+
+  style['visibility'] = this.getVisible_();
+};
+
+
+/**
+ * Get the visibility of the label.
+ * @private
+ * @return {string} blank string if visible, 'hidden' if invisible.
+ */
+olgm.gm.MapLabel.prototype.getVisible_ = function() {
+  var minZoom = /** @type {number} */ (this.get('minZoom'));
+  var maxZoom = /** @type {number} */ (this.get('maxZoom'));
+
+  if (minZoom === undefined && maxZoom === undefined) {
+    return '';
+  }
+
+  var map = this.getMap();
+  if (!map) {
+    return '';
+  }
+
+  var mapZoom = map.getZoom();
+  if (mapZoom < minZoom || mapZoom > maxZoom) {
+    return 'hidden';
+  }
+  return '';
+};
+
+
+/**
+ * @inheritDoc
+ */
+olgm.gm.MapLabel.prototype.onRemove = function() {
+  var canvas = this.canvas_;
+  if (canvas && canvas.parentNode) {
+    canvas.parentNode.removeChild(canvas);
+  }
+};

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -112,8 +112,10 @@ olgm.herald.VectorSource.prototype.watchFeature_ = function(feature) {
   // push to features (internal)
   this.features_.push(feature);
 
+  var index = this.features_.indexOf(feature);
+
   // create and activate feature herald
-  var herald = new olgm.herald.Feature(ol3map, gmap, feature, data);
+  var herald = new olgm.herald.Feature(ol3map, gmap, feature, data, index);
   herald.activate();
 
   // push to cache

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -34,6 +34,26 @@ olgm.RESOLUTIONS = [
 
 
 /**
+ * @param {ol.geom.Geometry} geometry
+ * @return {ol.Coordinate}
+ */
+olgm.getCenterOf = function(geometry) {
+
+  var center = null;
+
+  if (geometry instanceof ol.geom.Point) {
+    center = geometry.getCoordinates();
+  } else if (geometry instanceof ol.geom.Polygon) {
+    center = geometry.getInteriorPoint().getCoordinates();
+  } else {
+    center = ol.extent.getCenter(geometry.getExtent());
+  }
+
+  return center;
+};
+
+
+/**
  * @param {string|Array.<number>} color
  * @return {string}
  */
@@ -86,6 +106,32 @@ olgm.getColorOpacity = function(color) {
   }
 
   return opacity;
+};
+
+
+/**
+ * Get the style from the specified object.
+ * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature} object
+
+ * @return {?ol.style.Style}
+ */
+olgm.getStyleOf = function(object) {
+
+  var style = null;
+
+  if (object instanceof ol.style.Style) {
+    style = object;
+  } else if (object instanceof ol.layer.Vector ||
+             object instanceof ol.Feature) {
+    style = object.getStyle();
+    if (style && style instanceof Function) {
+      style = style()[0]; // todo - support multiple styles ?
+    }
+  } else if (object instanceof Function) {
+    style = object()[0]; // todo - support multiple styles ?
+  }
+
+  return style;
 };
 
 


### PR DESCRIPTION
This PR introduces the support of vector labels in OL3 to Google Maps.  It includes:
- the addition of the MapLabel, a library that takes care of adding the text labels in Google Maps.  It was modified to support most of the features possible to do in OL3
- a new example that shows the labels in action
- a new entry to the limitations about labels (because they come with limitations)
