### PR TITLE
Fix label font color

### DIFF
--- a/examples/label.js
+++ b/examples/label.js
@@ -47,10 +47,9 @@ feature3.setStyle(new ol.style.Style({
   text: new ol.style.Text({
     textAlign: 'left',
     textBaseline: 'bottom',
-    font: 'normal 10pt Arial',
+    font: 'normal 11pt Arial',
     text: 'Bottom-Left',
-    fill: new ol.style.Fill({color: 'black'}),
-    stroke: new ol.style.Stroke({color: 'white', width: 3})
+    fill: new ol.style.Fill({color: 'white'})
   })
 }));
 

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -288,6 +288,14 @@ olgm.gm.createLabel = function(textStyle, latLng, index) {
     labelOptions['font'] = font;
   }
 
+  var fill = textStyle.getFill();
+  if (fill) {
+    var fillColor = fill.getColor();
+    if (fillColor) {
+      labelOptions['fontColor'] = fillColor;
+    }
+  }
+
   var stroke = textStyle.getStroke();
   if (stroke) {
     var strokeColor = stroke.getColor();

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -43,10 +43,7 @@ goog.provide('olgm.gm.MapLabel');
  * @api
  */
 olgm.gm.MapLabel = function(opt_options) {
-  this.set('font', 'normal 12px sans-serif');
-  this.set('fontColor', '#000000');
-  this.set('strokeColor', '#ffffff');
-  this.set('strokeWeight', 4);
+  this.set('font', 'normal 10px sans-serif');
   this.set('textAlign', 'center');
   this.set('textBaseline', 'middle');
 
@@ -116,13 +113,19 @@ olgm.gm.MapLabel.prototype.drawCanvas_ = function() {
   if (!canvas) return;
 
   var style = canvas.style;
+
+  var fillStyle = this.get('fontColor');
+  if (!fillStyle) {
+    return;
+  }
+
   style.zIndex = /** @type {number} */ (this.get('zIndex'));
 
   var ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.textBaseline = this.get('textBaseline');
   ctx.strokeStyle = this.get('strokeColor');
-  ctx.fillStyle = this.get('fontColor');
+  ctx.fillStyle = fillStyle;
   ctx.font = this.get('font');
   ctx.textAlign = this.get('textAlign');
 


### PR DESCRIPTION
The label font color (fill/color) had been forgotten. This
patch fixes this issue.

Also, default values of MapLabel now match those of OL3 as well.
