### PR TITLE
Fix CSS while Google Maps is active

### DIFF
--- a/css/ol3gm.css
+++ b/css/ol3gm.css
@@ -1,0 +1,12 @@
+.gm-style {
+  font-size: inherit;
+  font-family: inherit;
+}
+
+.gm-style .ol-attribution {
+  bottom: 1em;
+}
+
+.gm-style .ol-attribution.ol-logo-only {
+  bottom: 1em;
+}

--- a/examples/concept.html
+++ b/examples/concept.html
@@ -7,6 +7,7 @@
     <title>ol3gm proof of concept example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
   <body>

--- a/examples/label.html
+++ b/examples/label.html
@@ -7,6 +7,7 @@
     <title>OL3-Google-Maps label example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
   <body>

--- a/examples/latest.html
+++ b/examples/latest.html
@@ -7,6 +7,7 @@
     <title>OL3-Google-Maps w. latest Google Maps example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
   <body>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -7,6 +7,7 @@
     <title>OL3-Google-Maps simple example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
   <body>

--- a/examples/vector.html
+++ b/examples/vector.html
@@ -7,6 +7,7 @@
     <title>OL3-Google-Maps vector example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
   <body>


### PR DESCRIPTION
When Google Maps is active, the CSS of the OL3 component changes.
This fix makes sure that the CSS stays 'as-is'.
