### PR TITLE
Add vector icon example

### DIFF
--- a/examples/icon.html
+++ b/examples/icon.html
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps icon example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Icon example</h4>
+          <p>
+            Demonstrates the support of icon vector style by OL3-Google-Maps.
+          </p>
+
+          <input id="toggle" type="button" onclick="toggle();"
+                 value="Toggle Between OL3 and GMAPS" />
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../ol3/build/ol.js"></script>
+
+    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+
+    <script src="/@loader"></script>
+    <script src="icon.js"></script>
+  </body>
+</html>

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -1,0 +1,49 @@
+var center = [-7908084, 6177492];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var source = new ol.source.Vector();
+var feature = new ol.Feature(new ol.geom.Point(center));
+feature.setStyle(new ol.style.Style({
+    image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+      anchor: [0.5, 46],
+      anchorXUnits: 'fraction',
+      anchorYUnits: 'pixels',
+      size: [32, 48],
+      scale: 0.75,
+      src: 'data/icon.png'
+    }))
+  }));
+source.addFeature(feature);
+var vector = new ol.layer.Vector({
+  source: source
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    vector
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 12
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+
+function toggle() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};


### PR DESCRIPTION
This PR introduces a new simple example featuring a single vector feature that use icon style.  It also shows the support of `scale`.
