### PR TITLE
Add themed gmap support, i.e. styles for Google Maps

### DIFF
--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -31,7 +31,8 @@ olgmx.layer = {};
 
 /**
  * @typedef {{
- *   mapTypeId: (google.maps.MapTypeId.<(number|string)>|string|undefined)
+ *   mapTypeId: (google.maps.MapTypeId.<(number|string)>|string|undefined),
+ *   styles: (Array.<google.maps.MapTypeStyle>|undefined)
  * }}
  * @api
  */
@@ -45,3 +46,11 @@ olgmx.layer.GoogleOptions;
  * @api
  */
 olgmx.layer.GoogleOptions.prototype.mapTypeId;
+
+
+/**
+ * The Google Maps styles to apply to the map
+ * @type {Array.<google.maps.MapTypeStyle>|undefined}
+ * @api
+ */
+olgmx.layer.GoogleOptions.prototype.styles;

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -410,6 +410,14 @@ olgm.herald.Layers.prototype.toggleGoogleMaps_ = function() {
   if (found) {
     // set mapTypeId
     this.gmap.setMapTypeId(found.getMapTypeId());
+    // set styles
+    var styles = found.getStyles();
+    if (styles) {
+      this.gmap.setOptions({'styles': styles});
+    } else {
+      this.gmap.setOptions({'styles': null});
+    }
+
     // activate
     this.activateGoogleMaps_();
   } else {

--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -25,6 +25,12 @@ olgm.layer.Google = function(opt_options) {
   this.mapTypeId_ = options.mapTypeId !== undefined ? options.mapTypeId :
       google.maps.MapTypeId.ROADMAP;
 
+  /**
+   * @type {?Array.<google.maps.MapTypeStyle>}
+   * @private
+   */
+  this.styles_ = options.styles ? options.styles : null;
+
 };
 goog.inherits(olgm.layer.Google, ol.layer.Group);
 
@@ -34,4 +40,12 @@ goog.inherits(olgm.layer.Google, ol.layer.Group);
  */
 olgm.layer.Google.prototype.getMapTypeId = function() {
   return this.mapTypeId_;
+};
+
+
+/**
+ * @return {?Array.<google.maps.MapTypeStyle>}
+ */
+olgm.layer.Google.prototype.getStyles = function() {
+  return this.styles_;
 };


### PR DESCRIPTION
This PR introduces the support of themed Google Maps map through a new option in the `olgm.layer.Google` object: `styles`.
