### PR TITLE
Fix activation of vector source herald

### DIFF
--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -373,10 +373,10 @@ olgm.herald.Layers.prototype.activateGoogleMaps_ = function() {
   this.viewHerald_.setCenter();
   this.viewHerald_.setZoom();
 
+  this.googleMapsIsActive_ = true;
+
   // activate all cache items
   this.vectorCache_.forEach(this.activateVectorLayerCacheItem_, this);
-
-  this.googleMapsIsActive_ = true;
 };
 
 


### PR DESCRIPTION
This PR fixes the bug that vector source heralds were not activated after a late Google Maps activation.
