### PR TITLE
Mark getMapTypeId as @api

### DIFF
--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -37,6 +37,7 @@ goog.inherits(olgm.layer.Google, ol.layer.Group);
 
 /**
  * @return {google.maps.MapTypeId.<(number|string)>|string}
+ * @api
  */
 olgm.layer.Google.prototype.getMapTypeId = function() {
   return this.mapTypeId_;


### PR DESCRIPTION
This PR allows to obtain the map type id from a `olgm.layer.Google` in the minimized version.
