### PR TITLE
Remove dependency on Google Maps when loading the library

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -19,7 +19,7 @@ var umdWrapper = '(function (root, factory) {\n' +
     '  if (typeof exports === "object") {\n' +
     '    module.exports = factory(root.ol);\n' +
     '  } else if (typeof define === "function" && define.amd) {\n' +
-    '    define([\'ol\', \'googlemaps\'], factory);\n' +
+    '    define([\'ol\'], factory);\n' +
     '  } else {\n' +
     '    root.olgm = factory(root.ol);\n' +
     '  }\n' +

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -51,7 +51,9 @@ olgm.gm.MapLabel = function(opt_options) {
 
   this.setValues(opt_options);
 };
-goog.inherits(olgm.gm.MapLabel, google.maps.OverlayView);
+if (window.google && window.google.maps) {
+  goog.inherits(olgm.gm.MapLabel, google.maps.OverlayView);
+}
 
 
 /**


### PR DESCRIPTION
This PR removes the dependency on Google Maps when loading the library.

This may seem like a odd thing to do.  Let me explain.  In an application, which is installed for many different clients all over the world, the library OLGM is included.  Google Maps is not always included, though, which causes OLGM to fail when being loaded because it contains a class that extend one from Google Maps: `google.maps.OverlayView`.  Without this fix, the library had to be dynamically loaded after detecting if Google Maps was actually loaded, which was kind of a pain.

With this fix, we can now mindlessly always load the library but simply not use it if Google Maps is not included, which is much easier to accomplish.

This PR also removes the dependency to Google Maps in the `define` method in the compiled version.
