### PR TITLE
Include OpenLayers as node module instead of git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ol3"]
-	path = ol3
-	url = https://github.com/openlayers/ol3.git

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 npm-install: .build/node_modules.timestamp
 
 .PHONY: serve
-serve: npm-install ol3/build/olX
+serve: npm-install node_modules/openlayers/build/olX
 	node build/serve.js
 
 .PHONY: dist
@@ -61,10 +61,10 @@ check: lint dist .build/geojsonhint.timestamp
 .PHONY: clean
 clean:
 	rm -f dist/ol3gm.js
-	rm -f ol3/build/ol.js
-	rm -f ol3/build/ol-debug.js
-	rm -f ol3/build/ol.css
-	rm -f ol3/build/ol-externs.js
+	rm -f node_modules/openlayers/build/ol.js
+	rm -f node_modules/openlayers/build/ol-debug.js
+	rm -f node_modules/openlayers/build/ol.css
+	rm -f node_modules/openlayers/build/ol-externs.js
 	rm -rf dist/ol3
 	rm -rf dist/examples
 
@@ -81,17 +81,17 @@ cleanall: clean
 	.build/python-venv/bin/gjslint --jslint_error=all --strict --custom_jsdoc_tags=api $?
 	touch $@
 
-.build/dist-examples.timestamp: ol3/build/olX dist/ol3gm.js $(EXAMPLES_JS_FILES) $(EXAMPLES_HTML_FILES)
+.build/dist-examples.timestamp: node_modules/openlayers/build/olX dist/ol3gm.js $(EXAMPLES_JS_FILES) $(EXAMPLES_HTML_FILES)
 	node build/parse-examples.js
 	mkdir -p $(dir $@)
 	mkdir -p dist/ol3
-	cp ol3/build/ol-debug.js dist/ol3/
-	cp ol3/build/ol.js dist/ol3/
+	cp node_modules/openlayers/build/ol-debug.js dist/ol3/
+	cp node_modules/openlayers/build/ol.js dist/ol3/
 	mkdir -p dist/ol3/css
-	cp ol3/build/ol.css dist/ol3/css/
+	cp node_modules/openlayers/build/ol.css dist/ol3/css/
 	cp -R examples dist/
 	for f in dist/examples/*.html; do $(SEDI) 'sY/@loaderY../ol3gm.jsY' $$f; done
-	for f in dist/examples/*.html; do $(SEDI) 'sY../ol3/build/ol.jsY../ol3/ol-debug.jsY' $$f; done
+	for f in dist/examples/*.html; do $(SEDI) 'sY../node_modules/openlayers/build/ol.jsY../node_modules/openlayers/ol-debug.jsY' $$f; done
 	touch $@
 
 .build/python-venv:
@@ -102,12 +102,12 @@ cleanall: clean
 	.build/python-venv/bin/pip install "http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
 	touch $@
 
-dist/ol3gm-debug.js: build/ol3gm-debug.json $(SRC_JS_FILES) ol3/build/ol-externs.js build/build.js npm-install
+dist/ol3gm-debug.js: build/ol3gm-debug.json $(SRC_JS_FILES) node_modules/openlayers/build/ol-externs.js build/build.js npm-install
 	mkdir -p $(dir $@)
 	node build/build.js $< $@
 
 # A sourcemap is prepared, the source is exected to be deployed in 'source' directory
-dist/ol3gm.js: build/ol3gm.json $(SRC_JS_FILES) ol3/build/ol-externs.js build/build.js npm-install
+dist/ol3gm.js: build/ol3gm.json $(SRC_JS_FILES) node_modules/openlayers/build/ol-externs.js build/build.js npm-install
 	mkdir -p $(dir $@)
 	node build/build.js $< $@
 	$(SEDI) 's!$(shell pwd)/dist!source!g' dist/ol3gm.js.map
@@ -115,10 +115,10 @@ dist/ol3gm.js: build/ol3gm.json $(SRC_JS_FILES) ol3/build/ol-externs.js build/bu
 #	echo '//# sourceMappingURL=ol3gm.js.map' >> dist/ol3gm.js
 #	-ln -s .. dist/source
 
-.PHONY: ol3/build/ol-externs.js
-ol3/build/ol-externs.js:
-	(cd ol3 && npm install && node tasks/generate-externs.js build/ol-externs.js)
+.PHONY: node_modules/openlayers/build/ol-externs.js
+node_modules/openlayers/build/ol-externs.js:
+	(cd node_modules/openlayers && npm install && node tasks/generate-externs.js build/ol-externs.js)
 
-.PHONY: ol3/build/olX
-ol3/build/olX:
-	(cd ol3 && npm install && make build)
+.PHONY: node_modules/openlayers/build/olX
+node_modules/openlayers/build/olX:
+	(cd node_modules/openlayers && npm install && make build)

--- a/build/ol3gm.json
+++ b/build/ol3gm.json
@@ -5,9 +5,9 @@
   "ignoreRequires": "^ol\\.",
   "compile": {
     "externs": [
-      "ol3/build/ol-externs.js",
-      "ol3/externs/esrijson.js",
-      "ol3/externs/proj4js.js",
+      "node_modules/openlayers/build/ol-externs.js",
+      "node_modules/openlayers/externs/esrijson.js",
+      "node_modules/openlayers/externs/proj4js.js",
       "externs/olgmx.js",
       "externs/google_maps_api_v3_21.js"
     ],

--- a/examples/concept.html
+++ b/examples/concept.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>ol3gm proof of concept example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -89,7 +89,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- local -->
     <script type="text/javascript"

--- a/examples/icon.html
+++ b/examples/icon.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps icon example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -32,7 +32,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/examples/label.html
+++ b/examples/label.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps label example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -38,7 +38,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/examples/latest.html
+++ b/examples/latest.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps w. latest Google Maps example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -33,7 +33,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps simple example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -35,7 +35,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/examples/themed.html
+++ b/examples/themed.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps themed example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -32,7 +32,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/examples/vector.html
+++ b/examples/vector.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps vector example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
@@ -38,7 +38,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "graceful-fs": "~3.0.2",
     "jsdoc": "~3.3.0-alpha7",
     "jshint": "~2.5.1",
+    "openlayers": "mapgears/ol3#v3.13.1-olgm",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",
     "walk": "~2.3.3"


### PR DESCRIPTION
In order to make the installation procedure much easier,
this patches makes openlayers no longer included as a git
submodule, but as a node module instead.

Also, the version of openlayers is upgraded to master
(2016-01-29), with the addition to one patch that prevents the
ol3-externs.js file to throw errors when used in the build.
That patch is currently under a PR:
https://github.com/openlayers/ol3/pull/4756
