### PR TITLE
Upgrade to OL3 v3.14.2

### DIFF
--- a/build/ol3gm.json
+++ b/build/ol3gm.json
@@ -8,6 +8,7 @@
       "node_modules/openlayers/build/ol-externs.js",
       "node_modules/openlayers/externs/esrijson.js",
       "node_modules/openlayers/externs/proj4js.js",
+      "node_modules/openlayers/externs/tilejson.js",
       "externs/olgmx.js",
       "externs/google_maps_api_v3_21.js"
     ],

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "graceful-fs": "~3.0.2",
     "jsdoc": "~3.3.0-alpha7",
     "jshint": "~2.5.1",
-    "openlayers": "mapgears/ol3#v3.13.1-olgm",
+    "openlayers": "mapgears/ol3#v3.14.2-olgm",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",
     "walk": "~2.3.3"

--- a/src/herald/herald.js
+++ b/src/herald/herald.js
@@ -1,6 +1,5 @@
 goog.provide('olgm.herald.Herald');
 
-goog.require('goog.events');
 goog.require('olgm');
 goog.require('olgm.Abstract');
 
@@ -19,10 +18,16 @@ goog.require('olgm.Abstract');
 olgm.herald.Herald = function(ol3map, gmap) {
 
   /**
-   * @type {Array.<goog.events.Key>}
+   * @type {Array.<ol.events.Key|Array.<ol.events.Key>>}
    * @protected
    */
   this.listenerKeys = [];
+
+  /**
+   * @type {Array.<goog.events.Key>}
+   * @protected
+   */
+  this.googListenerKeys = [];
 
   goog.base(this, ol3map, gmap);
 };
@@ -39,5 +44,5 @@ olgm.herald.Herald.prototype.activate = function() {};
  * Unregister all event listeners.
  */
 olgm.herald.Herald.prototype.deactivate = function() {
-  olgm.unlistenAllByKey(this.listenerKeys);
+  olgm.unlistenAllByKey(this.listenerKeys, this.googListenerKeys);
 };

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -508,7 +508,7 @@ olgm.herald.Layers.prototype.handleVectorLayerVisibleChange_ = function(
 /**
  * @typedef {{
  *   layer: (olgm.layer.Google),
- *   listenerKeys: (Array.<goog.events.Key>)
+ *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>)
  * }}
  */
 olgm.herald.Layers.GoogleLayerCache;
@@ -519,7 +519,7 @@ olgm.herald.Layers.GoogleLayerCache;
  *   data: (google.maps.Data),
  *   herald: (olgm.herald.VectorSource),
  *   layer: (ol.layer.Vector),
- *   listenerKeys: (Array.<goog.events.Key>),
+ *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
  *   opacity: (number)
  * }}
  */

--- a/src/herald/viewherald.js
+++ b/src/herald/viewherald.js
@@ -51,7 +51,7 @@ olgm.herald.View.prototype.activate = function() {
   keys.push(view.on('change:resolution', this.setZoom, this));
 
   // listen to browser window resize
-  keys.push(goog.events.listen(
+  this.googListenerKeys.push(goog.events.listen(
       window,
       goog.events.EventType.RESIZE,
       this.handleWindowResize_,

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -1,7 +1,5 @@
 goog.provide('olgm');
 
-goog.require('goog.events');
-
 
 /**
  * @type {!Array.<number>}
@@ -54,7 +52,7 @@ olgm.getCenterOf = function(geometry) {
 
 
 /**
- * @param {string|Array.<number>} color
+ * @param {string|Array.<number>|CanvasGradient|CanvasPattern} color
  * @return {string}
  */
 olgm.getColor = function(color) {
@@ -69,10 +67,11 @@ olgm.getColor = function(color) {
     } else {
       out = color;
     }
-  } else {
-    // is array
+  } else if (Array.isArray(color)) {
     rgba = color;
   }
+
+  // Todo - support CanvasGradient and CanvasPattern
 
   if (rgba !== null) {
     out = ['rgb(', rgba[0], ',', rgba[1], ',', rgba[2], ')'].join('');
@@ -83,7 +82,7 @@ olgm.getColor = function(color) {
 
 
 /**
- * @param {string|Array.<number>} color
+ * @param {string|Array.<number>|CanvasGradient|CanvasPattern} color
  * @return {?number}
  */
 olgm.getColorOpacity = function(color) {
@@ -96,10 +95,11 @@ olgm.getColorOpacity = function(color) {
     if (olgm.stringStartsWith(color, 'rgba')) {
       rgba = olgm.parseRGBA(color);
     }
-  } else {
-    // is array
+  } else if (Array.isArray(color)) {
     rgba = color;
   }
+
+  // Todo - support CanvasGradient and CanvasPattern
 
   if (rgba && rgba[3] !== undefined) {
     opacity = +rgba[3];
@@ -189,9 +189,14 @@ olgm.stringStartsWith = function(string, needle) {
 
 
 /**
- * @param {Array.<goog.events.Key>} listenerKeys
+ * @param {Array.<ol.events.Key|Array.<ol.events.Key>>} listenerKeys
+ * @param {Array.<goog.events.Key>=} opt_googListenerKeys
  */
-olgm.unlistenAllByKey = function(listenerKeys) {
+olgm.unlistenAllByKey = function(listenerKeys, opt_googListenerKeys) {
   listenerKeys.forEach(ol.Observable.unByKey);
   listenerKeys.length = 0;
+  if (opt_googListenerKeys) {
+    opt_googListenerKeys.forEach(goog.events.unlistenByKey);
+    opt_googListenerKeys.length = 0;
+  }
 };


### PR DESCRIPTION
This PR upgrades the OL3 version from 3.13.1 to 3.14.2.

Note that the version used is not exactly v3.14.2.  It contains additional patches to be able to make the build run properly.  This won't affect the usability of the OLGM lib with any version of OL3 v3.14.x, but it makes it now depend on v3.14.x or higher.
