### PR TITLE
Dispatch event after setVisible on Google layer

### DIFF
--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -50,3 +50,24 @@ olgm.layer.Google.prototype.getMapTypeId = function() {
 olgm.layer.Google.prototype.getStyles = function() {
   return this.styles_;
 };
+
+
+/**
+ * Set the visibility of the google layer (`true` or `false`). This is a
+ * temporary fix for issue #60. The only thing different about this function,
+ * which overrides the layerbase's setVisible function, is that it sends an
+ * event manually right after.
+ * We're doing this fix because for an unknown reason, when both OLGM and
+ * OL3 are compiled and used at the same time, the layer's observable
+ * properties don't fire change events anymore for the Google layer.
+ * @param {boolean} visible The visibility of the layer.
+ * @observable
+ * @api stable
+ */
+olgm.layer.Google.prototype.setVisible = function(visible) {
+  // Call the original setVisible function
+  goog.base(this, 'setVisible', visible);
+
+  // Dispatch a change event right after
+  this.dispatchEvent('change:visible');
+};


### PR DESCRIPTION
This commit is a temporary fix for issue #60. It adds a setVisible
function to the Google layer class, which calls the original
parent function and dispatches a change:visible event. This is
because for an unknown reason, when both OLGM and OL3 are compiled
and used at the same time, the layer's observable properties don't
fire change events anymore for the Google layer.
