### PR TITLE
Add support for WMS layers

### DIFF
--- a/examples/wms.html
+++ b/examples/wms.html
@@ -24,6 +24,9 @@
             Shows that WMS layers added to OL3 are ported to Google Maps
             when the latter gets activated.
           </p>
+
+          <input id="toggle" type="button" onclick="toggle();"
+                 value="Toggle Between OL3 and GMAPS" />
         </div>
       </div>
     </div>

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -25,8 +25,10 @@
             when the latter gets activated.
           </p>
 
-          <input id="toggle" type="button" onclick="toggle();"
+          <input id="toggleOSM" type="button" onclick="toggleOSM();"
                  value="Toggle between OL3 and GMAPS" />
+          <input id="toggleWMS" type="button" onclick="toggleWMS();"
+                 value="Toggle between tiled WMS and image WMS" />
         </div>
       </div>
     </div>

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps WMS example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>WMS example</h4>
+          <p>
+            Shows that WMS layers added to OL3 are ported to Google Maps
+            when the latter gets activated.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <script src="../ol3/build/ol.js"></script>
+
+    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+
+    <script src="/@loader"></script>
+    <script src="wms.js"></script>
+  </body>
+</html>

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="index, all" />
     <title>OL3-Google-Maps WMS example</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
     <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
   </head>
   <body>
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <script src="../ol3/build/ol.js"></script>
+    <script src="../node_modules/openlayers/build/ol.js"></script>
 
     <!-- GoogleMaps API Key for 127.0.0.1 -->
     <script type="text/javascript"

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -26,7 +26,7 @@
           </p>
 
           <input id="toggle" type="button" onclick="toggle();"
-                 value="Toggle Between OL3 and GMAPS" />
+                 value="Toggle between OL3 and GMAPS" />
         </div>
       </div>
     </div>

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -29,6 +29,8 @@
                  value="Toggle between OL3 and GMAPS" />
           <input id="toggleWMS" type="button" onclick="toggleWMS();"
                  value="Toggle between tiled WMS and image WMS" />
+          <span>Current mode: </span>
+          <span id="currentMode">tiled</span>
         </div>
       </div>
     </div>

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -54,4 +54,6 @@ function toggleOSM() {
 function toggleWMS() {
   tileWMSLayer.setVisible(!tileWMSLayer.getVisible());
   imageWMSLayer.setVisible(!imageWMSLayer.getVisible());
+  var spanText = tileWMSLayer.getVisible() ? 'tiled' : 'image';
+  document.getElementById('currentMode').innerHTML = spanText;
 }

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -8,12 +8,13 @@ var osmLayer = new ol.layer.Tile({
 });
 
 var tileWMSLayer  =  new ol.layer.Tile({
-    extent: [-13884991, 2870341, -7455066, 6338219],
-    source: new ol.source.TileWMS({
-      url: 'http://demo.boundlessgeo.com/geoserver/wms',
-      params: {'LAYERS': 'topp:states', 'TILED': true},
-      serverType: 'geoserver'
-    })
+  extent: [-13884991, 2870341, -7455066, 6338219],
+  source: new ol.source.TileWMS({
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    params: {'LAYERS': 'topp:states', 'TILED': true},
+    serverType: 'geoserver'
+  }),
+  visible: true
 });
 
 var map = new ol.Map({

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -1,0 +1,29 @@
+var center = [-10997148, 4569099];
+
+var googleLayer = new olgm.layer.Google();
+
+var wmsLayer =  new ol.layer.Image({
+    extent: [-13884991, 2870341, -7455066, 6338219],
+    source: new ol.source.ImageWMS({
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
+      params: {'LAYERS': 'topp:states'},
+      serverType: 'geoserver'
+    })
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    wmsLayer,
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -17,13 +17,24 @@ var tileWMSLayer  =  new ol.layer.Tile({
   visible: true
 });
 
+var imageWMSLayer = new ol.layer.Image({
+  extent: [-13884991, 2870341, -7455066, 6338219],
+  source: new ol.source.ImageWMS({
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    params: {'LAYERS': 'topp:states', 'TILED': true},
+    serverType: 'geoserver'
+  }),
+  visible: false
+})
+
 var map = new ol.Map({
   // use OL3-Google-Maps recommended default interactions
   interactions: olgm.interaction.defaults(),
   layers: [
     googleLayer,
     osmLayer,
-    tileWMSLayer
+    tileWMSLayer,
+    imageWMSLayer
   ],
   target: 'map',
   view: new ol.View({
@@ -35,7 +46,12 @@ var map = new ol.Map({
 var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
 olGM.activate();
 
-function toggle() {
+function toggleOSM() {
   googleLayer.setVisible(!googleLayer.getVisible());
   osmLayer.setVisible(!osmLayer.getVisible());
 };
+
+function toggleWMS() {
+  tileWMSLayer.setVisible(!tileWMSLayer.getVisible());
+  imageWMSLayer.setVisible(!imageWMSLayer.getVisible());
+}

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -2,11 +2,16 @@ var center = [-10997148, 4569099];
 
 var googleLayer = new olgm.layer.Google();
 
-var wmsLayer =  new ol.layer.Image({
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var tileWMSLayer  =  new ol.layer.Tile({
     extent: [-13884991, 2870341, -7455066, 6338219],
-    source: new ol.source.ImageWMS({
+    source: new ol.source.TileWMS({
       url: 'http://demo.boundlessgeo.com/geoserver/wms',
-      params: {'LAYERS': 'topp:states'},
+      params: {'LAYERS': 'topp:states', 'TILED': true},
       serverType: 'geoserver'
     })
 });
@@ -16,7 +21,8 @@ var map = new ol.Map({
   interactions: olgm.interaction.defaults(),
   layers: [
     googleLayer,
-    wmsLayer,
+    osmLayer,
+    tileWMSLayer
   ],
   target: 'map',
   view: new ol.View({
@@ -27,3 +33,8 @@ var map = new ol.Map({
 
 var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
 olGM.activate();
+
+function toggle() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -1,0 +1,94 @@
+goog.provide('olgm.gm.ImageOverlay');
+
+
+
+/**
+ * Creates a new image overlay.
+ * @constructor
+ * @extends {google.maps.OverlayView}
+ * @param {string} src url to the image
+ * @param {Array.<number>} size size of the image
+ * @param {google.maps.LatLng} topLeft topLeft corner
+ * @api
+ */
+olgm.gm.ImageOverlay = function(src, size, topLeft) {
+  /**
+   * @type {string}
+   * @private
+   */
+  olgm.gm.ImageOverlay.prototype.src_ = src;
+
+  /**
+   * @type {Array.<number>}
+   * @private
+   */
+  olgm.gm.ImageOverlay.prototype.size_ = size;
+
+  /**
+   * @type {google.maps.LatLng}
+   * @private
+   */
+  olgm.gm.ImageOverlay.prototype.topLeft_ = topLeft;
+
+  /**
+   * @type {Element}
+   * @private
+   */
+  olgm.gm.ImageOverlay.prototype.div_ = null;
+};
+if (window.google && window.google.maps) {
+  goog.inherits(olgm.gm.ImageOverlay, google.maps.OverlayView);
+}
+
+
+/**
+ * Note: mark as `@api` to make the minimized version include this method.
+ * @api
+ */
+olgm.gm.ImageOverlay.prototype.onAdd = function() {
+  var div = document.createElement('div');
+  div.style.borderStyle = 'none';
+  div.style.borderWidth = '0px';
+  div.style.position = 'absolute';
+
+  // Create the img element and attach it to the div.
+  var img = document.createElement('img');
+  img.src = this.src_;
+  img.style.width = '100%';
+  img.style.height = '100%';
+  img.style.position = 'absolute';
+  div.appendChild(img);
+
+  this.div_ = div;
+
+  // Add the element to the "overlayLayer" pane.
+  var panes = this.getPanes();
+  panes.overlayLayer.appendChild(div);
+};
+
+
+/**
+ * Note: mark as `@api` to make the minimized version include this method.
+ * @api
+ */
+olgm.gm.ImageOverlay.prototype.draw = function() {
+  var div = this.div_;
+  div.style.width = this.size_[0] + 'px';
+  div.style.height = this.size_[1] + 'px';
+
+  var overlayProjection = this.getProjection();
+  var topLeftPx = overlayProjection.fromLatLngToDivPixel(this.topLeft_);
+
+  div.style.top = topLeftPx.y + 'px';
+  div.style.left = topLeftPx.x + 'px';
+};
+
+
+/**
+ * Note: mark as `@api` to make the minimized version include this method.
+ * @api
+ */
+olgm.gm.ImageOverlay.prototype.onRemove = function() {
+  this.div_.parentNode.removeChild(this.div_);
+  this.div_ = null;
+};

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -73,14 +73,33 @@ olgm.gm.ImageOverlay.prototype.onAdd = function() {
  */
 olgm.gm.ImageOverlay.prototype.draw = function() {
   var div = this.div_;
-  div.style.width = this.size_[0] + 'px';
-  div.style.height = this.size_[1] + 'px';
+
+  var sizeX = this.size_[0];
+  var sizeY = this.size_[1];
+
+  div.style.width = sizeX + 'px';
+  div.style.height = sizeY + 'px';
 
   var overlayProjection = this.getProjection();
   var topLeftPx = overlayProjection.fromLatLngToDivPixel(this.topLeft_);
 
-  div.style.top = topLeftPx.y + 'px';
-  div.style.left = topLeftPx.x + 'px';
+  var offsetX = topLeftPx.x;
+  var offsetY = topLeftPx.y;
+
+  // Adjust bad calculations when the view is larger than the world
+  var worldWidth = overlayProjection.getWorldWidth();
+  if (worldWidth < sizeX) {
+    // Overlap of the map on each size
+    var mapOverlap = Math.floor(sizeX / worldWidth) / 2;
+
+    // For when only one map is overlapping
+    var factor = Math.max(mapOverlap, 1);
+
+    offsetX -= worldWidth * factor;
+  }
+
+  div.style.top = offsetY + 'px';
+  div.style.left = offsetX + 'px';
 };
 
 

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -267,6 +267,7 @@ olgm.herald.Layers.prototype.watchTileWMSLayer_ = function(layer) {
   if (!source) {
     return;
   }
+  var params = source.getParams();
 
   this.tileWMSLayers_.push(layer);
 
@@ -284,7 +285,8 @@ olgm.herald.Layers.prototype.watchTileWMSLayer_ = function(layer) {
   var proj = ol.proj.get('EPSG:3857');
 
   var googleGetTileUrlFunction = function(coords, zoom) {
-    return getTileUrlFunction([zoom, coords.x, (-coords.y) - 1], 1, proj);
+    var ol3Coords = [zoom, coords.x, (-coords.y) - 1];
+    return getTileUrlFunction(ol3Coords, 1, proj, params);
   };
 
   var tileSize = new google.maps.Size(256, 256);
@@ -297,7 +299,9 @@ olgm.herald.Layers.prototype.watchTileWMSLayer_ = function(layer) {
 
   // Create the WMS layer on the google layer
   var googleWMSLayer = new google.maps.ImageMapType(options);
-  this.gmap.overlayMapTypes.push(googleWMSLayer);
+  if (layer.getVisible()) {
+    this.gmap.overlayMapTypes.push(googleWMSLayer);
+  }
   cacheItem.googleWMSLayer = googleWMSLayer;
 
   // Hide the google layer when the ol3 layer is invisible
@@ -635,11 +639,13 @@ olgm.herald.Layers.prototype.handleTileWMSLayerVisibleChange_ = function(
     if (layerIndex == -1) {
       googleMapsLayers.push(googleWMSLayer);
     }
+    this.activateTileWMSLayerCacheItem_(cacheItem);
   } else {
     // Remove the google WMS layer from the map if it hasn't been done already
     if (layerIndex != -1) {
       googleMapsLayers.removeAt(layerIndex);
     }
+    this.deactivateTileWMSLayerCacheItem_(cacheItem);
   }
 };
 

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -330,9 +330,7 @@ olgm.herald.Layers.prototype.generateImageWMSFunction_ = function(layer) {
   var url = source.getUrl();
   var size = ol3map.getSize();
 
-  if (!size) {
-    return '';
-  }
+  goog.asserts.assert(size !== undefined);
 
   var view = ol3map.getView();
   var bbox = view.calculateExtent(size);
@@ -859,9 +857,7 @@ olgm.herald.Layers.prototype.updateImageOverlay_ = function(cacheItem) {
   var view = this.ol3map.getView();
   var size = this.ol3map.getSize();
 
-  if (!size) {
-    return;
-  }
+  goog.asserts.assert(size !== undefined);
 
   var extent = view.calculateExtent(size);
 

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -706,6 +706,7 @@ olgm.herald.Layers.prototype.activateImageWMSLayerCacheItem_ = function(
   var layer = cacheItem.layer;
   var visible = layer.getVisible();
   if (visible && this.googleMapsIsActive_) {
+    cacheItem.lastUrl = null;
     cacheItem.layer.setOpacity(0);
     this.updateImageOverlay_(cacheItem);
   }


### PR DESCRIPTION
This commit adds support to WMS layers, either tiled with a `ol.layer.Tile` object and a `ol.source.TileWMS` source or as a single image with a `ol.layer.Image` object and a `ol.source.ImageWMS` source.

For the tiled source: we start by getting the original's source url function. This function can be sent coordinates and a projection and it will return a WMS request url. We create another function that takes in parameter google tile coordinates and a zoom level, and returns the appropriate WMS request url. This function is given to a new `google.maps.ImageMapType` object, which calls it whenever needed. We remove the ImageMapType from the map whenever it's not visible anymore.

For the image source: we create a new ImageOverlay. This is a new object that extends from google.maps.OverlayView. It has three major functions: onAdd, draw and onRemove, which all do exactly what they sound like. This object needs to be sent a few parameters to function: the url of the image (the WMS request), the size in pixels and the location in latitude/longitude of the top left corner of the image.
This object is deleted and re-created every time the map is panned or zoomed in.
