### PR TITLE
Compile ol3-google-maps with ol3

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -138,7 +138,6 @@ function getDependencies(config, exports, callback) {
         cwd: root
       };
     }
-    options.ignoreRequires = config.ignoreRequires;
     closure.getDependencies(options, function(err, paths) {
       if (err) {
         callback(err);
@@ -163,14 +162,8 @@ function concatenate(paths, callback) {
       var msg = 'Trouble concatenating sources.  ' + err.message;
       callback(new Error(msg));
     } else {
-      var parts = umdWrapper.split('%output%');
-      var src = parts[0] +
-          'var goog = this.goog = {};\n' +
-          'this.CLOSURE_NO_DEPS = true;\n' +
-          results.join('\n') +
-          'OL3GOOGLEMAPS.olgm = olgm;\n' +
-          parts[1];
-      callback(null, src);
+      var preamble = 'var CLOSURE_NO_DEPS = true;\n';
+      callback(null, preamble + results.join('\n'));
     }
   });
 }

--- a/build/generate-exports.js
+++ b/build/generate-exports.js
@@ -54,7 +54,7 @@ function getConfig(configPath, callback) {
 /**
  * Read the symbols from info file.
  * @param {Array.<string>} patterns List of patterns to pass along.
- * @param {funciton(Error, Array.<string>, Array.<Object>)} callback Called
+ * @param {function(Error, Array.<string>, Array.<Object>)} callback Called
  *     with the patterns and symbols (or any error).
  */
 function getSymbols(patterns, callback) {
@@ -175,7 +175,7 @@ function generateExports(symbols, namespace) {
   blocks.unshift(
       '/**\n' +
       ' * @fileoverview Custom exports file.\n' +
-      ' * @suppress {checkVars}\n' +
+      ' * @suppress {checkVars,extraRequire}\n' +
       ' */\n');
   return blocks.join('\n');
 }

--- a/build/ol3gm-debug.json
+++ b/build/ol3gm-debug.json
@@ -1,5 +1,10 @@
 {
-  "ignoreRequires": "^ol\\.",
+
   "exports": ["*"],
-  "umd": true
+  "src": [
+    "node_modules/openlayers/src/**/*.js",
+    "node_modules/openlayers/build/ol.ext/*.js",
+    "src/**/*.js"
+  ],
+  "umd": false
 }

--- a/build/ol3gm.json
+++ b/build/ol3gm.json
@@ -1,19 +1,28 @@
 {
   "exports": ["*"],
-  "umd": true,
-  "src": ["src/**/*.js"],
-  "ignoreRequires": "^ol\\.",
+  "umd": false,
+  "src": [
+    "src/**/*.js",
+    "node_modules/openlayers/src/**/*.js",
+    "node_modules/openlayers/build/ol.ext/*.js"
+  ],
   "compile": {
     "externs": [
-      "node_modules/openlayers/build/ol-externs.js",
-      "node_modules/openlayers/externs/esrijson.js",
+      "externs/olgmx.js",
+      "node_modules/openlayers/externs/oli.js",
+      "node_modules/openlayers/externs/olx.js",
+      "node_modules/openlayers/externs/cartodb.js",
       "node_modules/openlayers/externs/proj4js.js",
       "node_modules/openlayers/externs/tilejson.js",
-      "externs/olgmx.js",
+      "node_modules/openlayers/externs/topojson.js",
+      "node_modules/openlayers/externs/esrijson.js",
+      "node_modules/openlayers/externs/geojson.js",
+      "node_modules/openlayers/externs/bingmaps.js",
+      "node_modules/openlayers/externs/closure-compiler.js",
       "externs/google_maps_api_v3_21.js"
     ],
     "define": [
-      "goog.DEBUG=true"
+      "goog.DEBUG=false"
     ],
     "js": [
     ],
@@ -28,8 +37,10 @@
     "extra_annotation_name": [
       "api", "observable"
     ],
-    "compilation_level": "ADVANCED_OPTIMIZATIONS",
+    "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
+    "generate_exports": true,
+    "output_wrapper": "(function(){%output%}).call(window);",
     "use_types_for_optimization": true,
     "create_source_map": "dist/ol3gm.js.map",
     "source_map_format": "V3"

--- a/build/ol3gm.json
+++ b/build/ol3gm.json
@@ -18,39 +18,12 @@
     "js": [
     ],
     "jscomp_error": [
-      "accessControls",
-      "ambiguousFunctionDecl",
-      "checkDebuggerStatement",
-      "checkEventfulObjectDisposal",
-      "checkProvides",
-      "checkRegExp",
-      "checkStructDictInheritance",
-      "checkVars",
-      "checkTypes",
-      "const",
-      "constantProperty",
-      "deprecated",
-      "duplicate",
-      "duplicateMessage",
-      "es3",
-      "externsValidation",
-      "fileoverviewTags",
-      "globalThis",
-      "internetExplorerChecks",
-      "invalidCasts",
-      "misplacedTypeAnnotation",
-      "missingProperties",
-      "nonStandardJsDocs",
-      "strictModuleDepCheck",
-      "suspiciousCode",
-      "typeInvalidation",
-      "tweakValidation",
-      "undefinedNames",
-      "undefinedVars",
-      "unknownDefines",
-      "uselessCode",
-      "violatedModuleDep",
-      "visibility"
+      "*"
+    ],
+    "jscomp_off": [
+      "useOfGoogBase",
+      "lintChecks",
+      "analyzerChecks"
     ],
     "extra_annotation_name": [
       "api", "observable"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
-    "closure-util": "0.19.0",
+    "closure-util": "1.14.0",
     "geojsonhint": "^1.0.0",
     "fs-extra": "~0.8.1",
     "graceful-fs": "~3.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "geojsonhint": "^1.0.0",
     "fs-extra": "~0.8.1",
     "graceful-fs": "~3.0.2",
-    "jsdoc": "~3.3.0-alpha7",
+    "jsdoc": "~3.4.0",
     "jshint": "~2.5.1",
     "openlayers": "mapgears/ol3#v3.15.0-olgm",
     "nomnom": "~1.6.2",

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -597,7 +597,8 @@ olgm.herald.Layers.prototype.activateGoogleMaps_ = function() {
 
   this.targetEl_.removeChild(this.ol3mapEl_);
   this.targetEl_.appendChild(this.gmapEl_);
-  this.gmap.controls[google.maps.ControlPosition.TOP_LEFT].push(
+  var index = parseInt(google.maps.ControlPosition.TOP_LEFT, 10);
+  this.gmap.controls[index].push(
       this.ol3mapEl_);
 
   this.viewHerald_.activate();
@@ -631,7 +632,8 @@ olgm.herald.Layers.prototype.deactivateGoogleMaps_ = function() {
     return;
   }
 
-  this.gmap.controls[google.maps.ControlPosition.TOP_LEFT].removeAt(0);
+  var index = parseInt(google.maps.ControlPosition.TOP_LEFT, 10);
+  this.gmap.controls[index].removeAt(0);
   this.targetEl_.removeChild(this.gmapEl_);
   this.targetEl_.appendChild(this.ol3mapEl_);
 

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -323,6 +323,8 @@ olgm.herald.Layers.prototype.watchImageWMSLayer_ = function(layer) {
  */
 olgm.herald.Layers.prototype.generateImageWMSFunction_ = function(layer) {
   var source = layer.getSource();
+  goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
+
   var params = source.getParams();
   var ol3map = this.ol3map;
 
@@ -371,7 +373,7 @@ olgm.herald.Layers.prototype.watchTileWMSLayer_ = function(layer) {
   if (!source) {
     return;
   }
-  var params = source.getParams();
+  goog.asserts.assertInstanceof(source, ol.source.TileWMS);
 
   this.tileWMSLayers_.push(layer);
 
@@ -390,7 +392,7 @@ olgm.herald.Layers.prototype.watchTileWMSLayer_ = function(layer) {
 
   var googleGetTileUrlFunction = function(coords, zoom) {
     var ol3Coords = [zoom, coords.x, (-coords.y) - 1];
-    return getTileUrlFunction(ol3Coords, 1, proj, params);
+    return getTileUrlFunction(ol3Coords, 1, proj);
   };
 
   var tileSize = new google.maps.Size(256, 256);

--- a/src/interaction/interactiondefaults.js
+++ b/src/interaction/interactiondefaults.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.interaction');
 
+goog.require('ol.interaction.DragPan');
+
 
 /**
  * Set of interactions that are recommended to include in ol3 maps used

--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.layer.Google');
 
+goog.require('ol.layer.Group');
+
 
 
 /**
@@ -49,24 +51,4 @@ olgm.layer.Google.prototype.getMapTypeId = function() {
  */
 olgm.layer.Google.prototype.getStyles = function() {
   return this.styles_;
-};
-
-
-/**
- * Set the visibility of the google layer (`true` or `false`). This is a
- * temporary fix for issue #60. The only thing different about this function,
- * which overrides the layerbase's setVisible function, is that it sends an
- * event manually right after.
- * We're doing this fix because for an unknown reason, when both OLGM and
- * OL3 are compiled and used at the same time, the layer's observable
- * properties don't fire change events anymore for the Google layer.
- * @param {boolean} visible The visibility of the layer.
- * @api stable
- */
-olgm.layer.Google.prototype.setVisible = function(visible) {
-  // Call the original setVisible function
-  goog.base(this, 'setVisible', visible);
-
-  // Dispatch a change event right after
-  this.dispatchEvent('change:visible');
 };

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -1,9 +1,7 @@
 goog.provide('olgm.OLGoogleMaps');
 
-goog.require('goog.asserts');
 goog.require('olgm.Abstract');
 goog.require('olgm.herald.Layers');
-goog.require('olgm.herald.View');
 
 
 


### PR DESCRIPTION
This commit makes the library build with ol3, fixing issues occurring only on the production version such as issue #60. It also updates closure-util and jsdoc. The suggested approach after applying this commit is:
- mv node_modules node_modules_old
- make clean
- npm install
- make dist

If it works, delete node_modules_old.
