### PR TITLE
Split LayersHerald into different files

### DIFF
--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -127,9 +127,7 @@ olgm.herald.ImageWMSSource.prototype.activateCacheItem_ = function(
  */
 olgm.herald.ImageWMSSource.prototype.deactivate = function() {
   olgm.herald.ImageWMSSource.base(this, 'deactivate'); //Call parent function
-  //console.log("TEST");
   this.cache_.forEach(this.deactivateCacheItem_, this);
-  //console.log("TEST END");
 };
 
 
@@ -140,14 +138,11 @@ olgm.herald.ImageWMSSource.prototype.deactivate = function() {
  */
 olgm.herald.ImageWMSSource.prototype.deactivateCacheItem_ = function(
     cacheItem) {
-  //console.log("deactivate");
   if (cacheItem.imageOverlay) {
     cacheItem.imageOverlay.setMap(null);
     cacheItem.imageOverlay = null;
   }
-  //console.log("opacity start");
   cacheItem.layer.setOpacity(cacheItem.opacity);
-  //console.log("opacity end");
 };
 
 

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -1,0 +1,300 @@
+goog.provide('olgm.herald.ImageWMSSource');
+
+goog.require('olgm.gm.ImageOverlay');
+goog.require('olgm.herald.Source');
+
+
+
+/**
+ * Listen to a Image WMS layer
+ * @param {!ol.Map} ol3map
+ * @param {!google.maps.Map} gmap
+ * @constructor
+ * @extends {olgm.herald.Source}
+ */
+olgm.herald.ImageWMSSource = function(ol3map, gmap) {
+  /**
+  * @type {Array.<olgm.herald.ImageWMSSource.LayerCache>}
+  * @private
+  */
+  this.cache_ = [];
+
+  /**
+  * @type {Array.<ol.layer.Image>}
+  * @private
+  */
+  this.layers_ = [];
+
+  goog.base(this, ol3map, gmap);
+};
+goog.inherits(olgm.herald.ImageWMSSource, olgm.herald.Source);
+
+
+/**
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.ImageWMSSource.prototype.watchLayer = function(layer) {
+  var imageLayer = /** {@type ol.layer.Image} */ (layer);
+  goog.asserts.assertInstanceof(imageLayer, ol.layer.Image);
+
+  var source = imageLayer.getSource();
+  if (!source) {
+    return;
+  }
+
+  this.layers_.push(imageLayer);
+
+  // opacity
+  var opacity = layer.getOpacity();
+
+  var cacheItem = /** {@type olgm.herald.ImageWMSSource.LayerCache} */ ({
+    imageOverlay: null,
+    lastUrl: null,
+    layer: imageLayer,
+    listenerKeys: [],
+    opacity: opacity
+  });
+
+  // Hide the google layer when the ol3 layer is invisible
+  cacheItem.listenerKeys.push(layer.on('change:visible',
+      this.handleVisibleChange_.bind(this, cacheItem), this));
+
+  cacheItem.listenerKeys.push(this.ol3map.on('moveend',
+      this.handleMoveEnd_.bind(this, cacheItem), this));
+
+  cacheItem.listenerKeys.push(this.ol3map.getView().on('change:resolution',
+      this.handleMoveEnd_.bind(this, cacheItem), this));
+
+  // Activate the cache item
+  this.activateCacheItem_(cacheItem);
+  this.cache_.push(cacheItem);
+};
+
+
+/**
+ * Unwatch the WMS Image layer
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.ImageWMSSource.prototype.unwatchLayer = function(layer) {
+  goog.asserts.assertInstanceof(layer, ol.layer.Image);
+  var index = this.layers_.indexOf(layer);
+  if (index !== -1) {
+    this.layers_.splice(index, 1);
+
+    var cacheItem = this.cache_[index];
+    olgm.unlistenAllByKey(cacheItem.listenerKeys);
+
+    // opacity
+    layer.setOpacity(cacheItem.opacity);
+
+    this.cache_.splice(index, 1);
+  }
+};
+
+
+/**
+ * Activate all cache items
+ * @override
+ */
+olgm.herald.ImageWMSSource.prototype.activate = function() {
+  olgm.herald.ImageWMSSource.base(this, 'activate'); // Call parent function
+  this.cache_.forEach(this.activateCacheItem_, this);
+};
+
+
+/**
+ * Activates an image WMS layer cache item.
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.ImageWMSSource.prototype.activateCacheItem_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+  if (visible && this.googleMapsIsActive) {
+    cacheItem.lastUrl = null;
+    cacheItem.layer.setOpacity(0);
+    this.updateImageOverlay_(cacheItem);
+  }
+};
+
+
+/**
+ * Deactivate all cache items
+ * @override
+ */
+olgm.herald.ImageWMSSource.prototype.deactivate = function() {
+  olgm.herald.ImageWMSSource.base(this, 'deactivate'); //Call parent function
+  //console.log("TEST");
+  this.cache_.forEach(this.deactivateCacheItem_, this);
+  //console.log("TEST END");
+};
+
+
+/**
+ * Deactivates an Image WMS layer cache item.
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.ImageWMSSource.prototype.deactivateCacheItem_ = function(
+    cacheItem) {
+  //console.log("deactivate");
+  if (cacheItem.imageOverlay) {
+    cacheItem.imageOverlay.setMap(null);
+    cacheItem.imageOverlay = null;
+  }
+  //console.log("opacity start");
+  cacheItem.layer.setOpacity(cacheItem.opacity);
+  //console.log("opacity end");
+};
+
+
+/**
+ * Generate a wms request url for a single image
+ * @param {ol.layer.Image} layer
+ * @return {string}
+ * @private
+ */
+olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
+    layer) {
+  var source = layer.getSource();
+  goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
+
+  var params = source.getParams();
+  var ol3map = this.ol3map;
+
+  //base WMS URL
+  var url = source.getUrl();
+  var size = ol3map.getSize();
+
+  goog.asserts.assert(size !== undefined);
+
+  var view = ol3map.getView();
+  var bbox = view.calculateExtent(size);
+
+  // Get params
+  var version = params['VERSION'] ? params['VERSION'] : '1.3.0';
+  var layers = params['LAYERS'] ? params['LAYERS'] : '';
+  var styles = params['STYLES'] ? params['STYLES'] : '';
+  var format = params['FORMAT'] ? params['FORMAT'] : 'image/png';
+  var transparent = params['TRANSPARENT'] ? params['TRANSPARENT'] : 'TRUE';
+  var tiled = params['TILED'] ? params['TILED'] : 'FALSE';
+
+  url += '?SERVICE=WMS';
+  url += '&VERSION=' + version;
+  url += '&REQUEST=GetMap';
+  url += '&LAYERS=' + layers;
+  url += '&STYLES=' + styles;
+  url += '&FORMAT=' + format;
+  url += '&TRANSPARENT=' + transparent;
+  url += '&SRS=EPSG:3857';
+  url += '&BBOX=' + bbox;
+  url += '&WIDTH=' + size[0];
+  url += '&HEIGHT=' + size[1];
+  url += '&TILED=' + tiled;
+
+  return url;
+};
+
+
+/**
+ * Refresh the custom image overlay on google maps
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(cacheItem) {
+  var layer = cacheItem.layer;
+  var url = this.generateImageWMSFunction_(layer);
+
+  /* We listen to both change:resolution and moveend events. However, changing
+   * resolution eventually sends a moveend event as well. Using only the
+   * moveend event makes zooming in/out look bad. To prevent rendering the
+   * overlay twice when it happens, we save the request url, and if it's the
+   * same as the last time, we don't render it.
+   */
+  if (url == cacheItem.lastUrl) {
+    return;
+  }
+
+  cacheItem.lastUrl = url;
+
+  // Create a new overlay
+  var view = this.ol3map.getView();
+  var size = this.ol3map.getSize();
+
+  goog.asserts.assert(size !== undefined);
+
+  var extent = view.calculateExtent(size);
+
+  // First, get the coordinates of the top left corner
+  var topLeft = ol.extent.getTopLeft(extent);
+
+  // Then, convert it to LatLng coordinates for google
+  var lngLat = ol.proj.transform(topLeft, 'EPSG:3857', 'EPSG:4326');
+  var topLeftLatLng = new google.maps.LatLng(lngLat[1], lngLat[0]);
+
+  var overlay = new olgm.gm.ImageOverlay(
+      url,
+      size,
+      topLeftLatLng);
+
+  // Set the new overlay right away to give it time to render
+  overlay.setMap(this.gmap);
+
+  // Clean previous overlay
+  if (cacheItem.imageOverlay) {
+    // Remove the overlay from the map
+    cacheItem.imageOverlay.setMap(null);
+
+    // Destroy the overlay
+    cacheItem.imageOverlay = null;
+  }
+
+  // Save new overlay
+  cacheItem.imageOverlay = overlay;
+};
+
+
+/**
+ * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.ImageWMSSource.prototype.handleVisibleChange_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+
+  if (visible) {
+    this.activateCacheItem_(cacheItem);
+  } else {
+    this.deactivateCacheItem_(cacheItem);
+  }
+};
+
+
+/**
+ * Handle the map being panned when an ImageWMS layer is present
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.ImageWMSSource.prototype.handleMoveEnd_ = function(
+    cacheItem) {
+  if (cacheItem.layer.getVisible()) {
+    this.updateImageOverlay_(cacheItem);
+  }
+};
+
+
+/**
+ * @typedef {{
+ *   imageOverlay: (olgm.gm.ImageOverlay),
+ *   lastUrl: (string|null),
+ *   layer: (ol.layer.Image),
+ *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   opacity: (number)
+ * }}
+ */
+olgm.herald.ImageWMSSource.LayerCache;

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -6,7 +6,7 @@ goog.require('olgm.gm');
 goog.require('olgm.herald.Herald');
 goog.require('olgm.herald.ImageWMSSource');
 goog.require('olgm.herald.TileWMSSource');
-goog.require('olgm.herald.VectorSource');
+goog.require('olgm.herald.VectorFeature');
 goog.require('olgm.herald.View');
 goog.require('olgm.layer.Google');
 
@@ -37,7 +37,7 @@ goog.require('olgm.layer.Google');
  *
  * `ol.layer.Vector`
  * -----------------
- *     When a vector layers is added, a `olgm.herald.VectorSource` is created
+ *     When a vector layers is added, a `olgm.herald.VectorFeature` is created
  *     to manage its `ol.source.Vector`. The layer is immediately rendered
  *     fully transparent, making the interactions still possible over it
  *     while being invisible.
@@ -305,7 +305,7 @@ olgm.herald.Layers.prototype.watchVectorLayer_ = function(layer) {
   }
 
   // herald
-  var herald = new olgm.herald.VectorSource(ol3map, gmap, source, data);
+  var herald = new olgm.herald.VectorFeature(ol3map, gmap, source, data);
 
   // opacity
   var opacity = layer.getOpacity();
@@ -569,7 +569,7 @@ olgm.herald.Layers.GoogleLayerCache;
 /**
  * @typedef {{
  *   data: (google.maps.Data),
- *   herald: (olgm.herald.VectorSource),
+ *   herald: (olgm.herald.VectorFeature),
  *   layer: (ol.layer.Vector),
  *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
  *   opacity: (number)

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -3,8 +3,9 @@ goog.provide('olgm.herald.Layers');
 goog.require('goog.asserts');
 goog.require('olgm');
 goog.require('olgm.gm');
-goog.require('olgm.gm.ImageOverlay');
 goog.require('olgm.herald.Herald');
+goog.require('olgm.herald.ImageWMSSource');
+goog.require('olgm.herald.TileWMSSource');
 goog.require('olgm.herald.VectorSource');
 goog.require('olgm.herald.View');
 goog.require('olgm.layer.Google');
@@ -74,28 +75,16 @@ olgm.herald.Layers = function(ol3map, gmap, watchVector) {
   this.vectorLayers_ = [];
 
   /**
-   * @type {Array.<olgm.herald.Layers.ImageWMSLayerCache>}
+   * @type {olgm.herald.ImageWMSSource}
    * @private
    */
-  this.imageWMSCache_ = [];
+  this.imageWMSSourceHerald_ = new olgm.herald.ImageWMSSource(ol3map, gmap);
 
   /**
-   * @type {Array.<ol.layer.Image>}
+   * @type {olgm.herald.TileWMSSource}
    * @private
    */
-  this.imageWMSLayers_ = [];
-
-  /**
-   * @type {Array.<olgm.herald.Layers.TileWMSLayerCache>}
-   * @private
-   */
-  this.tileWMSCache_ = [];
-
-  /**
-   * @type {Array.<ol.layer.Tile>}
-   * @private
-   */
-  this.tileWMSLayers_ = [];
+  this.tileWMSSourceHerald_ = new olgm.herald.TileWMSSource(ol3map, gmap);
 
   /**
    * @type {olgm.herald.View}
@@ -210,6 +199,18 @@ olgm.herald.Layers.prototype.getGoogleMapsActive = function() {
 
 
 /**
+ * Set the googleMapsIsActive value and spread the change to the heralds
+ * @param {boolean} active
+ * @private
+ */
+olgm.herald.Layers.prototype.setGoogleMapsActive_ = function(active) {
+  this.googleMapsIsActive_ = active;
+  this.imageWMSSourceHerald_.setGoogleMapsActive(active);
+  this.tileWMSSourceHerald_.setGoogleMapsActive(active);
+};
+
+
+/**
  * Callback method fired when a new layer is added to the map.
  * @param {ol.CollectionEvent} event Collection event.
  * @private
@@ -246,12 +247,12 @@ olgm.herald.Layers.prototype.watchLayer_ = function(layer) {
   } else if (layer instanceof ol.layer.Tile) {
     var source = layer.getSource();
     if (source instanceof ol.source.TileWMS) {
-      this.watchTileWMSLayer_(layer);
+      this.tileWMSSourceHerald_.watchLayer(layer);
     }
   } else if (layer instanceof ol.layer.Image) {
     var source = layer.getSource();
     if (source instanceof ol.source.ImageWMS) {
-      this.watchImageWMSLayer_(layer);
+      this.imageWMSSourceHerald_.watchLayer(layer);
     }
   }
 };
@@ -271,152 +272,6 @@ olgm.herald.Layers.prototype.watchGoogleLayer_ = function(layer) {
     ]
   }));
   this.toggleGoogleMaps_();
-};
-
-
-/**
- * Watch an image WMS layer, and create a layer on the google maps layer
- * @param {ol.layer.Image} layer
- * @private
- */
-olgm.herald.Layers.prototype.watchImageWMSLayer_ = function(layer) {
-  // Source required
-  var source = layer.getSource();
-  if (!source) {
-    return;
-  }
-
-  this.imageWMSLayers_.push(layer);
-
-  // opacity
-  var opacity = layer.getOpacity();
-
-  var cacheItem = /** {@type olgm.herald.Layers.ImageWMSLayerCache} */ ({
-    imageOverlay: null,
-    lastUrl: null,
-    layer: layer,
-    listenerKeys: [],
-    opacity: opacity
-  });
-
-  // Hide the google layer when the ol3 layer is invisible
-  cacheItem.listenerKeys.push(layer.on('change:visible',
-      this.handleImageWMSLayerVisibleChange_.bind(this, cacheItem), this));
-
-  cacheItem.listenerKeys.push(this.ol3map.on('moveend',
-      this.handleImageWMSMoveEnd_.bind(this, cacheItem), this));
-
-  cacheItem.listenerKeys.push(this.ol3map.getView().on('change:resolution',
-      this.handleImageWMSMoveEnd_.bind(this, cacheItem), this));
-
-  // Activate the cache item
-  this.activateImageWMSLayerCacheItem_(cacheItem);
-  this.imageWMSCache_.push(cacheItem);
-};
-
-
-/**
- * Generate a wms request url for a single image
- * @param {ol.layer.Image} layer
- * @return {string}
- * @private
- */
-olgm.herald.Layers.prototype.generateImageWMSFunction_ = function(layer) {
-  var source = layer.getSource();
-  goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
-
-  var params = source.getParams();
-  var ol3map = this.ol3map;
-
-  //base WMS URL
-  var url = source.getUrl();
-  var size = ol3map.getSize();
-
-  goog.asserts.assert(size !== undefined);
-
-  var view = ol3map.getView();
-  var bbox = view.calculateExtent(size);
-
-  // Get params
-  var version = params['VERSION'] ? params['VERSION'] : '1.3.0';
-  var layers = params['LAYERS'] ? params['LAYERS'] : '';
-  var styles = params['STYLES'] ? params['STYLES'] : '';
-  var format = params['FORMAT'] ? params['FORMAT'] : 'image/png';
-  var transparent = params['TRANSPARENT'] ? params['TRANSPARENT'] : 'TRUE';
-  var tiled = params['TILED'] ? params['TILED'] : 'FALSE';
-
-  url += '?SERVICE=WMS';
-  url += '&VERSION=' + version;
-  url += '&REQUEST=GetMap';
-  url += '&LAYERS=' + layers;
-  url += '&STYLES=' + styles;
-  url += '&FORMAT=' + format;
-  url += '&TRANSPARENT=' + transparent;
-  url += '&SRS=EPSG:3857';
-  url += '&BBOX=' + bbox;
-  url += '&WIDTH=' + size[0];
-  url += '&HEIGHT=' + size[1];
-  url += '&TILED=' + tiled;
-
-  return url;
-};
-
-
-/**
- * Watch a tiled WMS layer, and create a layer on the google maps layer
- * @param {ol.layer.Tile} layer
- * @private
- */
-olgm.herald.Layers.prototype.watchTileWMSLayer_ = function(layer) {
-  // Source required
-  var source = layer.getSource();
-  if (!source) {
-    return;
-  }
-  goog.asserts.assertInstanceof(source, ol.source.TileWMS);
-
-  this.tileWMSLayers_.push(layer);
-
-  // opacity
-  var opacity = layer.getOpacity();
-
-  var cacheItem = /** {@type olgm.herald.Layers.TileWMSLayerCache} */ ({
-    googleWMSLayer: null,
-    layer: layer,
-    listenerKeys: [],
-    opacity: opacity
-  });
-
-  var getTileUrlFunction = source.getTileUrlFunction();
-  var proj = ol.proj.get('EPSG:3857');
-
-  var googleGetTileUrlFunction = function(coords, zoom) {
-    var ol3Coords = [zoom, coords.x, (-coords.y) - 1];
-    return getTileUrlFunction(ol3Coords, 1, proj);
-  };
-
-  var tileSize = new google.maps.Size(256, 256);
-
-  var options = {
-    'getTileUrl': googleGetTileUrlFunction,
-    'tileSize': tileSize,
-    'isPng': true
-  };
-
-  // Create the WMS layer on the google layer
-  var googleWMSLayer = new google.maps.ImageMapType(options);
-  if (layer.getVisible()) {
-    this.gmap.overlayMapTypes.push(googleWMSLayer);
-  }
-  cacheItem.googleWMSLayer = googleWMSLayer;
-
-  // Hide the google layer when the ol3 layer is invisible
-  cacheItem.listenerKeys.push(layer.on('change:visible',
-      this.handleTileWMSLayerVisibleChange_.bind(this, cacheItem), this));
-
-  // Activate the cache item
-  this.activateTileWMSLayerCacheItem_(cacheItem);
-  this.tileWMSCache_.push(cacheItem);
 };
 
 
@@ -485,12 +340,12 @@ olgm.herald.Layers.prototype.unwatchLayer_ = function(layer) {
   } else if (layer instanceof ol.layer.Tile) {
     var source = layer.getSource();
     if (source instanceof ol.source.TileWMS) {
-      this.unwatchTileWMSLayer_(layer);
+      this.tileWMSSourceHerald_.unwatchLayer(layer);
     }
   } else if (layer instanceof ol.layer.Image) {
     var source = layer.getSource();
     if (source instanceof ol.source.ImageWMS) {
-      this.unwatchImageWMSLayer_(layer);
+      this.imageWMSSourceHerald_.unwatchLayer(layer);
     }
   }
 };
@@ -512,48 +367,6 @@ olgm.herald.Layers.prototype.unwatchGoogleLayer_ = function(layer) {
     this.googleCache_.splice(index, 1);
 
     this.toggleGoogleMaps_();
-  }
-};
-
-
-/**
- * Unwatch the WMS Image layer
- * @param {ol.layer.Image} layer
- * @private
- */
-olgm.herald.Layers.prototype.unwatchImageWMSLayer_ = function(layer) {
-  var index = this.imageWMSLayers_.indexOf(layer);
-  if (index !== -1) {
-    this.imageWMSLayers_.splice(index, 1);
-
-    var cacheItem = this.imageWMSCache_[index];
-    olgm.unlistenAllByKey(cacheItem.listenerKeys);
-
-    // opacity
-    layer.setOpacity(cacheItem.opacity);
-
-    this.imageWMSCache_.splice(index, 1);
-  }
-};
-
-
-/**
- * Unwatch the WMS Tile layer
- * @param {ol.layer.Tile} layer
- * @private
- */
-olgm.herald.Layers.prototype.unwatchTileWMSLayer_ = function(layer) {
-  var index = this.tileWMSLayers_.indexOf(layer);
-  if (index !== -1) {
-    this.tileWMSLayers_.splice(index, 1);
-
-    var cacheItem = this.tileWMSCache_[index];
-    olgm.unlistenAllByKey(cacheItem.listenerKeys);
-
-    // opacity
-    layer.setOpacity(cacheItem.opacity);
-
-    this.tileWMSCache_.splice(index, 1);
   }
 };
 
@@ -614,12 +427,12 @@ olgm.herald.Layers.prototype.activateGoogleMaps_ = function() {
   this.viewHerald_.setCenter();
   this.viewHerald_.setZoom();
 
-  this.googleMapsIsActive_ = true;
+  this.setGoogleMapsActive_(true);
 
   // activate all cache items
   this.vectorCache_.forEach(this.activateVectorLayerCacheItem_, this);
-  this.tileWMSCache_.forEach(this.activateTileWMSLayerCacheItem_, this);
-  this.imageWMSCache_.forEach(this.activateImageWMSLayerCacheItem_, this);
+  this.tileWMSSourceHerald_.activate();
+  this.imageWMSSourceHerald_.activate();
 };
 
 
@@ -645,10 +458,10 @@ olgm.herald.Layers.prototype.deactivateGoogleMaps_ = function() {
 
   // deactivate all cache items
   this.vectorCache_.forEach(this.deactivateVectorLayerCacheItem_, this);
-  this.tileWMSCache_.forEach(this.deactivateTileWMSLayerCacheItem_, this);
-  this.imageWMSCache_.forEach(this.deactivateImageWMSLayerCacheItem_, this);
+  this.tileWMSSourceHerald_.deactivate();
+  this.imageWMSSourceHerald_.deactivate();
 
-  this.googleMapsIsActive_ = false;
+  this.setGoogleMapsActive_(false);
 };
 
 
@@ -699,64 +512,6 @@ olgm.herald.Layers.prototype.toggleGoogleMaps_ = function() {
 
 
 /**
- * Activates an image WMS layer cache item.
- * @param {olgm.herald.Layers.ImageWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.activateImageWMSLayerCacheItem_ = function(
-    cacheItem) {
-  var layer = cacheItem.layer;
-  var visible = layer.getVisible();
-  if (visible && this.googleMapsIsActive_) {
-    cacheItem.lastUrl = null;
-    cacheItem.layer.setOpacity(0);
-    this.updateImageOverlay_(cacheItem);
-  }
-};
-
-
-/**
- * Deactivates an Image WMS layer cache item.
- * @param {olgm.herald.Layers.ImageWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.deactivateImageWMSLayerCacheItem_ = function(
-    cacheItem) {
-  if (cacheItem.imageOverlay) {
-    cacheItem.imageOverlay.setMap(null);
-    cacheItem.imageOverlay = null;
-  }
-  cacheItem.layer.setOpacity(cacheItem.opacity);
-};
-
-
-/**
- * Activates a tiled WMS layer cache item.
- * @param {olgm.herald.Layers.TileWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.activateTileWMSLayerCacheItem_ = function(
-    cacheItem) {
-  var layer = cacheItem.layer;
-  var visible = layer.getVisible();
-  if (visible && this.googleMapsIsActive_) {
-    cacheItem.layer.setOpacity(0);
-  }
-};
-
-
-/**
- * Deactivates a tiled WMS layer cache item.
- * @param {olgm.herald.Layers.TileWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.deactivateTileWMSLayerCacheItem_ = function(
-    cacheItem) {
-  cacheItem.layer.setOpacity(cacheItem.opacity);
-};
-
-
-/**
  * Activates a vector layer cache item, i.e. activate its herald and
  * render the layer invisible. Will only do so if the layer is visible.
  * @param {olgm.herald.Layers.VectorLayerCache} cacheItem
@@ -783,127 +538,6 @@ olgm.herald.Layers.prototype.deactivateVectorLayerCacheItem_ = function(
     cacheItem) {
   cacheItem.herald.deactivate();
   cacheItem.layer.setOpacity(cacheItem.opacity);
-};
-
-
-/**
- * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
- * @param {olgm.herald.Layers.TileWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.handleTileWMSLayerVisibleChange_ = function(
-    cacheItem) {
-  var layer = cacheItem.layer;
-  var visible = layer.getVisible();
-
-  var googleWMSLayer = cacheItem.googleWMSLayer;
-  var googleMapsLayers = this.gmap.overlayMapTypes;
-
-  // Get the position of the google layer so we can remove it
-  var layerIndex = googleMapsLayers.getArray().indexOf(googleWMSLayer);
-
-  if (visible) {
-    // Add the google WMS layer only if it's not there already
-    if (layerIndex == -1) {
-      googleMapsLayers.push(googleWMSLayer);
-    }
-    this.activateTileWMSLayerCacheItem_(cacheItem);
-  } else {
-    // Remove the google WMS layer from the map if it hasn't been done already
-    if (layerIndex != -1) {
-      googleMapsLayers.removeAt(layerIndex);
-    }
-    this.deactivateTileWMSLayerCacheItem_(cacheItem);
-  }
-};
-
-
-/**
- * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
- * @param {olgm.herald.Layers.ImageWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.handleImageWMSLayerVisibleChange_ = function(
-    cacheItem) {
-  var layer = cacheItem.layer;
-  var visible = layer.getVisible();
-
-  if (visible) {
-    this.activateImageWMSLayerCacheItem_(cacheItem);
-  } else {
-    this.deactivateImageWMSLayerCacheItem_(cacheItem);
-  }
-};
-
-
-/**
- * Refresh the custom image overlay on google maps
- * @param {olgm.herald.Layers.ImageWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.updateImageOverlay_ = function(cacheItem) {
-  var layer = cacheItem.layer;
-  var url = this.generateImageWMSFunction_(layer);
-
-  /* We listen to both change:resolution and moveend events. However, changing
-   * resolution eventually sends a moveend event as well. Using only the
-   * moveend event makes zooming in/out look bad. To prevent rendering the
-   * overlay twice when it happens, we save the request url, and if it's the
-   * same as the last time, we don't render it.
-   */
-  if (url == cacheItem.lastUrl) {
-    return;
-  }
-
-  cacheItem.lastUrl = url;
-
-  // Create a new overlay
-  var view = this.ol3map.getView();
-  var size = this.ol3map.getSize();
-
-  goog.asserts.assert(size !== undefined);
-
-  var extent = view.calculateExtent(size);
-
-  // First, get the coordinates of the top left corner
-  var topLeft = ol.extent.getTopLeft(extent);
-
-  // Then, convert it to LatLng coordinates for google
-  var lngLat = ol.proj.transform(topLeft, 'EPSG:3857', 'EPSG:4326');
-  var topLeftLatLng = new google.maps.LatLng(lngLat[1], lngLat[0]);
-
-  var overlay = new olgm.gm.ImageOverlay(
-      url,
-      size,
-      topLeftLatLng);
-
-  // Set the new overlay right away to give it time to render
-  overlay.setMap(this.gmap);
-
-  // Clean previous overlay
-  if (cacheItem.imageOverlay) {
-    // Remove the overlay from the map
-    cacheItem.imageOverlay.setMap(null);
-
-    // Destroy the overlay
-    cacheItem.imageOverlay = null;
-  }
-
-  // Save new overlay
-  cacheItem.imageOverlay = overlay;
-};
-
-
-/**
- * Handle the map being panned when an ImageWMS layer is present
- * @param {olgm.herald.Layers.ImageWMSLayerCache} cacheItem
- * @private
- */
-olgm.herald.Layers.prototype.handleImageWMSMoveEnd_ = function(
-    cacheItem) {
-  if (cacheItem.layer.getVisible()) {
-    this.updateImageOverlay_(cacheItem);
-  }
 };
 
 
@@ -942,26 +576,3 @@ olgm.herald.Layers.GoogleLayerCache;
  * }}
  */
 olgm.herald.Layers.VectorLayerCache;
-
-
-/**
- * @typedef {{
- *   googleWMSLayer: (google.maps.ImageMapType),
- *   layer: (ol.layer.Tile),
- *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
- *   opacity: (number)
- * }}
- */
-olgm.herald.Layers.TileWMSLayerCache;
-
-
-/**
- * @typedef {{
- *   imageOverlay: (olgm.gm.ImageOverlay),
- *   lastUrl: (string|null),
- *   layer: (ol.layer.Image),
- *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
- *   opacity: (number)
- * }}
- */
-olgm.herald.Layers.ImageWMSLayerCache;

--- a/src/herald/sourceherald.js
+++ b/src/herald/sourceherald.js
@@ -22,7 +22,7 @@ olgm.herald.Source = function(ol3map, gmap) {
    * @type {boolean}
    * @protected
    */
-  olgm.herald.Layers.prototype.googleMapsIsActive_ = false;
+  olgm.herald.Source.prototype.googleMapsIsActive_ = false;
 };
 goog.inherits(olgm.herald.Source, olgm.herald.Herald);
 

--- a/src/herald/sourceherald.js
+++ b/src/herald/sourceherald.js
@@ -1,0 +1,56 @@
+goog.provide('olgm.herald.Source');
+
+goog.require('olgm.herald.Herald');
+
+
+
+/**
+ * This is an abstract class. Children of this class will listen to one or
+ * multiple layers of a specific class to render them using the Google Maps
+ * API whenever a Google Maps layer is active.
+ * @param {!ol.Map} ol3map
+ * @param {!google.maps.Map} gmap
+ * @constructor
+ * @extends {olgm.herald.Herald}
+ */
+olgm.herald.Source = function(ol3map, gmap) {
+  goog.base(this, ol3map, gmap);
+
+  /**
+   * Flag that determines whether the GoogleMaps map is currently active, i.e.
+   * is currently shown and has the OpenLayers map added as one of its control.
+   * @type {boolean}
+   * @protected
+   */
+  olgm.herald.Layers.prototype.googleMapsIsActive_ = false;
+};
+goog.inherits(olgm.herald.Source, olgm.herald.Herald);
+
+
+/**
+ * Watch the layer. This adds the layer to the list of layers the herald is
+ * listening to, so that it can display it using Google Maps as soon as the
+ * layer becomes visible.
+ * @param {ol.layer.Base} layer
+ * @api
+ */
+olgm.herald.Source.prototype.watchLayer = goog.abstractMethod;
+
+
+/**
+ * Stop watching the layer. This removes the layer from the list of layers the
+ * herald is listening to, and restores its original opacity.
+ * @param {ol.layer.Base} layer
+ * @api
+ */
+olgm.herald.Source.prototype.unwatchLayer = goog.abstractMethod;
+
+
+/**
+ * Set the googleMapsIsActive value to true or false
+ * @param {boolean} active
+ * @api
+ */
+olgm.herald.Source.prototype.setGoogleMapsActive = function(active) {
+  this.googleMapsIsActive = active;
+};

--- a/src/herald/tilewmssourceherald.js
+++ b/src/herald/tilewmssourceherald.js
@@ -1,0 +1,202 @@
+goog.require('olgm.herald.Source');
+
+goog.provide('olgm.herald.TileWMSSource');
+
+
+
+/**
+ * Listen to a Tile WMS layer
+ * @param {!ol.Map} ol3map
+ * @param {!google.maps.Map} gmap
+ * @constructor
+ * @extends {olgm.herald.Source}
+ */
+olgm.herald.TileWMSSource = function(ol3map, gmap) {
+  /**
+  * @type {Array.<olgm.herald.TileWMSSource.LayerCache>}
+  * @private
+  */
+  this.cache_ = [];
+
+  /**
+  * @type {Array.<ol.layer.Tile>}
+  * @private
+  */
+  this.layers_ = [];
+
+  goog.base(this, ol3map, gmap);
+};
+goog.inherits(olgm.herald.TileWMSSource, olgm.herald.Source);
+
+
+/**
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.TileWMSSource.prototype.watchLayer = function(layer) {
+  var tileLayer = /** {@type ol.layer.Tile} */ (layer);
+  goog.asserts.assertInstanceof(tileLayer, ol.layer.Tile);
+
+  // Source required
+  var source = tileLayer.getSource();
+  if (!source) {
+    return;
+  }
+  goog.asserts.assertInstanceof(source, ol.source.TileWMS);
+
+  this.layers_.push(tileLayer);
+
+  // opacity
+  var opacity = tileLayer.getOpacity();
+
+  var cacheItem = /** {@type olgm.herald.Layers.TileWMSLayerCache} */ ({
+    googleWMSLayer: null,
+    layer: tileLayer,
+    listenerKeys: [],
+    opacity: opacity
+  });
+
+  var getTileUrlFunction = source.getTileUrlFunction();
+  var proj = ol.proj.get('EPSG:3857');
+
+  var googleGetTileUrlFunction = function(coords, zoom) {
+    var ol3Coords = [zoom, coords.x, (-coords.y) - 1];
+    return getTileUrlFunction(ol3Coords, 1, proj);
+  };
+
+  var tileSize = new google.maps.Size(256, 256);
+
+  var options = {
+    'getTileUrl': googleGetTileUrlFunction,
+    'tileSize': tileSize,
+    'isPng': true
+  };
+
+  // Create the WMS layer on the google layer
+  var googleWMSLayer = new google.maps.ImageMapType(options);
+  if (tileLayer.getVisible()) {
+    this.gmap.overlayMapTypes.push(googleWMSLayer);
+  }
+  cacheItem.googleWMSLayer = googleWMSLayer;
+
+  // Hide the google layer when the ol3 layer is invisible
+  cacheItem.listenerKeys.push(tileLayer.on('change:visible',
+      this.handleVisibleChange_.bind(this, cacheItem), this));
+
+  // Activate the cache item
+  this.activateCacheItem_(cacheItem);
+  this.cache_.push(cacheItem);
+};
+
+
+/**
+ * Unwatch the WMS tile layer
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.TileWMSSource.prototype.unwatchLayer = function(layer) {
+  var tileLayer = /** {@type ol.layer.Tile} */ (layer);
+  goog.asserts.assertInstanceof(tileLayer, ol.layer.Tile);
+
+  var index = this.layers_.indexOf(tileLayer);
+  if (index !== -1) {
+    this.layers_.splice(index, 1);
+
+    var cacheItem = this.cache_[index];
+    olgm.unlistenAllByKey(cacheItem.listenerKeys);
+
+    // opacity
+    tileLayer.setOpacity(cacheItem.opacity);
+
+    this.cache_.splice(index, 1);
+  }
+};
+
+
+/**
+ * Activate all cache items
+ * @api
+ */
+olgm.herald.TileWMSSource.prototype.activate = function() {
+  olgm.herald.TileWMSSource.base(this, 'activate'); // Call parent function
+  this.cache_.forEach(this.activateCacheItem_, this);
+};
+
+
+/**
+ * Activates an image WMS layer cache item.
+ * @param {olgm.herald.TileWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.TileWMSSource.prototype.activateCacheItem_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+  if (visible && this.googleMapsIsActive) {
+    cacheItem.layer.setOpacity(0);
+  }
+};
+
+
+/**
+ * Deactivate all cache items
+ * @api
+ */
+olgm.herald.TileWMSSource.prototype.deactivate = function() {
+  olgm.herald.TileWMSSource.base(this, 'deactivate'); //Call parent function
+  this.cache_.forEach(this.deactivateCacheItem_, this);
+};
+
+
+/**
+ * Deactivates a Tile WMS layer cache item.
+ * @param {olgm.herald.TileWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.TileWMSSource.prototype.deactivateCacheItem_ = function(
+    cacheItem) {
+  cacheItem.layer.setOpacity(cacheItem.opacity);
+};
+
+
+/**
+ * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
+ * @param {olgm.herald.TileWMSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.TileWMSSource.prototype.handleVisibleChange_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+
+  var googleWMSLayer = cacheItem.googleWMSLayer;
+  var googleMapsLayers = this.gmap.overlayMapTypes;
+
+  // Get the position of the google layer so we can remove it
+  var layerIndex = googleMapsLayers.getArray().indexOf(googleWMSLayer);
+
+  if (visible) {
+    // Add the google WMS layer only if it's not there already
+    if (layerIndex == -1) {
+      googleMapsLayers.push(googleWMSLayer);
+    }
+    this.activateCacheItem_(cacheItem);
+  } else {
+    // Remove the google WMS layer from the map if it hasn't been done already
+    if (layerIndex != -1) {
+      googleMapsLayers.removeAt(layerIndex);
+    }
+    this.deactivateCacheItem_(cacheItem);
+  }
+};
+
+
+/**
+ * @typedef {{
+ *   googleWMSLayer: (google.maps.ImageMapType),
+ *   layer: (ol.layer.Tile),
+ *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   opacity: (number)
+ * }}
+ */
+olgm.herald.TileWMSSource.LayerCache;

--- a/src/herald/tilewmssourceherald.js
+++ b/src/herald/tilewmssourceherald.js
@@ -1,6 +1,6 @@
-goog.require('olgm.herald.Source');
-
 goog.provide('olgm.herald.TileWMSSource');
+
+goog.require('olgm.herald.Source');
 
 
 
@@ -49,7 +49,7 @@ olgm.herald.TileWMSSource.prototype.watchLayer = function(layer) {
   // opacity
   var opacity = tileLayer.getOpacity();
 
-  var cacheItem = /** {@type olgm.herald.Layers.TileWMSLayerCache} */ ({
+  var cacheItem = /** {@type olgm.herald.TileWMSSource.LayerCache} */ ({
     googleWMSLayer: null,
     layer: tileLayer,
     listenerKeys: [],

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -1,4 +1,4 @@
-goog.provide('olgm.herald.VectorSource');
+goog.provide('olgm.herald.VectorFeature');
 
 goog.require('goog.asserts');
 goog.require('olgm.herald.Feature');
@@ -7,7 +7,7 @@ goog.require('olgm.herald.Herald');
 
 
 /**
- * The VectorSource Herald is responsible of sychronizing the features from
+ * The VectorFeature Herald is responsible of sychronizing the features from
  * an ol3 vector source. The existing features in addition of those that are
  * added and removed are all managed. Each existing or added feature is bound
  * to a `olgm.herald.Feature` object. It gets unbound when removed.
@@ -19,7 +19,7 @@ goog.require('olgm.herald.Herald');
  * @constructor
  * @extends {olgm.herald.Herald}
  */
-olgm.herald.VectorSource = function(ol3map, gmap, source, data) {
+olgm.herald.VectorFeature = function(ol3map, gmap, source, data) {
 
   /**
    * @type {Array.<ol.Feature>}
@@ -28,7 +28,7 @@ olgm.herald.VectorSource = function(ol3map, gmap, source, data) {
   this.features_ = [];
 
   /**
-   * @type {Array.<olgm.herald.VectorSource.Cache>}
+   * @type {Array.<olgm.herald.VectorFeature.Cache>}
    * @private
    */
   this.cache_ = [];
@@ -47,13 +47,13 @@ olgm.herald.VectorSource = function(ol3map, gmap, source, data) {
 
   goog.base(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.VectorSource, olgm.herald.Herald);
+goog.inherits(olgm.herald.VectorFeature, olgm.herald.Herald);
 
 
 /**
  * @inheritDoc
  */
-olgm.herald.VectorSource.prototype.activate = function() {
+olgm.herald.VectorFeature.prototype.activate = function() {
   goog.base(this, 'activate');
 
   // watch existing features...
@@ -69,7 +69,7 @@ olgm.herald.VectorSource.prototype.activate = function() {
 /**
  * @inheritDoc
  */
-olgm.herald.VectorSource.prototype.deactivate = function() {
+olgm.herald.VectorFeature.prototype.deactivate = function() {
   // unwatch existing features...
   this.source_.getFeatures().forEach(this.unwatchFeature_, this);
 
@@ -81,7 +81,7 @@ olgm.herald.VectorSource.prototype.deactivate = function() {
  * @param {ol.source.VectorEvent} event
  * @private
  */
-olgm.herald.VectorSource.prototype.handleAddFeature_ = function(event) {
+olgm.herald.VectorFeature.prototype.handleAddFeature_ = function(event) {
   var feature = event.feature;
   goog.asserts.assertInstanceof(feature, ol.Feature);
   this.watchFeature_(feature);
@@ -92,7 +92,7 @@ olgm.herald.VectorSource.prototype.handleAddFeature_ = function(event) {
  * @param {ol.source.VectorEvent} event
  * @private
  */
-olgm.herald.VectorSource.prototype.handleRemoveFeature_ = function(event) {
+olgm.herald.VectorFeature.prototype.handleRemoveFeature_ = function(event) {
   var feature = event.feature;
   goog.asserts.assertInstanceof(feature, ol.Feature);
   this.unwatchFeature_(feature);
@@ -103,7 +103,7 @@ olgm.herald.VectorSource.prototype.handleRemoveFeature_ = function(event) {
  * @param {ol.Feature} feature
  * @private
  */
-olgm.herald.VectorSource.prototype.watchFeature_ = function(feature) {
+olgm.herald.VectorFeature.prototype.watchFeature_ = function(feature) {
 
   var ol3map = this.ol3map;
   var gmap = this.gmap;
@@ -130,7 +130,7 @@ olgm.herald.VectorSource.prototype.watchFeature_ = function(feature) {
  * @param {ol.Feature} feature
  * @private
  */
-olgm.herald.VectorSource.prototype.unwatchFeature_ = function(feature) {
+olgm.herald.VectorFeature.prototype.unwatchFeature_ = function(feature) {
   var index = this.features_.indexOf(feature);
   if (index !== -1) {
     // remove from features (internal)
@@ -149,4 +149,4 @@ olgm.herald.VectorSource.prototype.unwatchFeature_ = function(feature) {
  *   herald: (olgm.herald.Feature)
  * }}
  */
-olgm.herald.VectorSource.Cache;
+olgm.herald.VectorFeature.Cache;

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -64,7 +64,7 @@ olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
   // opacity
   var opacity = vectorLayer.getOpacity();
 
-  var cacheItem = /** {@type olgm.herald.Layers.VectorLayerCache} */ ({
+  var cacheItem = /** {@type olgm.herald.VectorSource.LayerCache} */ ({
     data: data,
     herald: herald,
     layer: vectorLayer,

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -1,0 +1,189 @@
+goog.provide('olgm.herald.VectorSource');
+
+goog.require('olgm.herald.Source');
+goog.require('olgm.herald.VectorFeature');
+
+
+
+/**
+ * Listen to a Vector layer
+ * @param {!ol.Map} ol3map
+ * @param {!google.maps.Map} gmap
+ * @constructor
+ * @extends {olgm.herald.Source}
+ */
+olgm.herald.VectorSource = function(ol3map, gmap) {
+  /**
+  * @type {Array.<olgm.herald.VectorSource.LayerCache>}
+  * @private
+  */
+  this.cache_ = [];
+
+  /**
+  * @type {Array.<ol.layer.Vector>}
+  * @private
+  */
+  this.layers_ = [];
+
+  goog.base(this, ol3map, gmap);
+};
+goog.inherits(olgm.herald.VectorSource, olgm.herald.Source);
+
+
+/**
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
+  var vectorLayer = /** {@type ol.layer.Vector} */ (layer);
+  goog.asserts.assertInstanceof(vectorLayer, ol.layer.Vector);
+
+  // Source required
+  var source = vectorLayer.getSource();
+  if (!source) {
+    return;
+  }
+
+  this.layers_.push(vectorLayer);
+
+  // Data
+  var data = new google.maps.Data({
+    'map': this.gmap
+  });
+
+  // Style
+  var gmStyle = olgm.gm.createStyle(vectorLayer);
+  if (gmStyle) {
+    data.setStyle(gmStyle);
+  }
+
+  // herald
+  var herald = new olgm.herald.VectorFeature(
+      this.ol3map, this.gmap, source, data);
+
+  // opacity
+  var opacity = vectorLayer.getOpacity();
+
+  var cacheItem = /** {@type olgm.herald.Layers.VectorLayerCache} */ ({
+    data: data,
+    herald: herald,
+    layer: vectorLayer,
+    listenerKeys: [],
+    opacity: opacity
+  });
+
+  cacheItem.listenerKeys.push(vectorLayer.on('change:visible',
+      this.handleVisibleChange_.bind(this, cacheItem), this));
+
+  this.activateCacheItem_(cacheItem);
+
+  this.cache_.push(cacheItem);
+};
+
+
+/**
+ * Unwatch the WMS tile layer
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.VectorSource.prototype.unwatchLayer = function(layer) {
+  var vectorLayer = /** {@type ol.layer.Vector} */ (layer);
+  goog.asserts.assertInstanceof(vectorLayer, ol.layer.Vector);
+
+  var index = this.layers_.indexOf(vectorLayer);
+  if (index !== -1) {
+    this.layers_.splice(index, 1);
+
+    var cacheItem = this.cache_[index];
+    olgm.unlistenAllByKey(cacheItem.listenerKeys);
+
+    // data - unset
+    cacheItem.data.setMap(null);
+
+    // herald
+    cacheItem.herald.deactivate();
+
+    // opacity
+    vectorLayer.setOpacity(cacheItem.opacity);
+
+    this.cache_.splice(index, 1);
+  }
+
+};
+
+
+/**
+ * Activate all cache items
+ * @api
+ */
+olgm.herald.VectorSource.prototype.activate = function() {
+  olgm.herald.VectorSource.base(this, 'activate'); // Call parent function
+  this.cache_.forEach(this.activateCacheItem_, this);
+};
+
+
+/**
+ * Activates an image WMS layer cache item.
+ * @param {olgm.herald.VectorSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.VectorSource.prototype.activateCacheItem_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+  if (visible && this.googleMapsIsActive) {
+    cacheItem.herald.activate();
+    cacheItem.layer.setOpacity(0);
+  }
+};
+
+
+/**
+ * Deactivate all cache items
+ * @api
+ */
+olgm.herald.VectorSource.prototype.deactivate = function() {
+  olgm.herald.VectorSource.base(this, 'deactivate'); //Call parent function
+  this.cache_.forEach(this.deactivateCacheItem_, this);
+};
+
+
+/**
+ * Deactivates a Tile WMS layer cache item.
+ * @param {olgm.herald.VectorSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.VectorSource.prototype.deactivateCacheItem_ = function(
+    cacheItem) {
+  cacheItem.herald.deactivate();
+  cacheItem.layer.setOpacity(cacheItem.opacity);
+};
+
+
+/**
+ * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
+ * @param {olgm.herald.VectorSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.VectorSource.prototype.handleVisibleChange_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+  if (visible) {
+    this.activateCacheItem_(cacheItem);
+  } else {
+    this.deactivateCacheItem_(cacheItem);
+  }
+};
+
+
+/**
+ * @typedef {{
+ *   data: (google.maps.Data),
+ *   herald: (olgm.herald.VectorFeature),
+ *   layer: (ol.layer.Vector),
+ *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   opacity: (number)
+ * }}
+ */
+olgm.herald.VectorSource.LayerCache;


### PR DESCRIPTION
This commit splits the LayersHerald into different smaller files, reducing its number of lines from 967 to 436. These files are:
- imagewmssourceherald.js
- tilewmssourceherald.js
- vectorsourceherald.js

They all handle one type of layer/source to translate to the Google Maps API. They inherit from a new SourceHerald file. They all implement these functions:
- watchLayer
- unwatchLayer
- activate
- deactivate

They also all have a list of layers to listen to and a list of cacheItems to manage, as well as some listeners when necessary.
