### PR TITLE
Update ol3 to v3.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "graceful-fs": "~3.0.2",
     "jsdoc": "~3.4.0",
     "jshint": "~2.5.1",
-    "openlayers": "mapgears/ol3#v3.15.0-olgm",
+    "openlayers": "openlayers/ol3#v3.16.0",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",
     "walk": "~2.3.3"


### PR DESCRIPTION
After applying this commit, run `npm install` and `make dist` to rebuild the library with the new version of ol3.
