### PR TITLE
Add support for WMTS layers

### DIFF
--- a/examples/wmts.html
+++ b/examples/wmts.html
@@ -19,7 +19,7 @@
       </div>
       <div class="row-fluid">
         <div class="span12">
-          <h4>WMS example</h4>
+          <h4>WMTS example</h4>
           <p>
             Shows that WMTS layers added to OL3 are ported to Google Maps
             when the latter gets activated.

--- a/examples/wmts.html
+++ b/examples/wmts.html
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps WMTS example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>WMS example</h4>
+          <p>
+            Shows that WMTS layers added to OL3 are ported to Google Maps
+            when the latter gets activated.
+          </p>
+
+          <input id="toggleOSM" type="button" onclick="toggleOSM();"
+                 value="Toggle between OL3 and GMAPS" />
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+
+    <script src="/@loader"></script>
+    <script src="wmts.js"></script>
+  </body>
+</html>

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -1,0 +1,65 @@
+var center = [-10997148, 4569099];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+// Setup tilegrid for wmts layer
+var projection = ol.proj.get('EPSG:3857');
+var projectionExtent = projection.getExtent();
+var size = ol.extent.getWidth(projectionExtent) / 256;
+var resolutions = new Array(14);
+var matrixIds = new Array(14);
+for (var z = 0; z < 14; ++z) {
+  // generate resolutions and matrixIds arrays for this WMTS
+  resolutions[z] = size / Math.pow(2, z);
+  matrixIds[z] = z;
+}
+
+var wmtsLayer = new ol.layer.Tile({
+  opacity: 0.7,
+  source: new ol.source.WMTS({
+    attributions: 'Tiles © <a href="http://services.arcgisonline.com/arcgis/rest/' +
+        'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>',
+    url: 'http://services.arcgisonline.com/arcgis/rest/' +
+        'services/Demographics/USA_Population_Density/MapServer/WMTS/',
+    layer: '0',
+    matrixSet: 'EPSG:3857',
+    format: 'image/png',
+    projection: projection,
+    tileGrid: new ol.tilegrid.WMTS({
+      origin: ol.extent.getTopLeft(projectionExtent),
+      resolutions: resolutions,
+      matrixIds: matrixIds
+    }),
+    style: 'default',
+    wrapX: true
+  })
+});
+
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    wmtsLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+function toggleOSM() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -7,6 +7,7 @@ goog.require('olgm.herald.ImageWMSSource');
 goog.require('olgm.herald.TileWMSSource');
 goog.require('olgm.herald.VectorSource');
 goog.require('olgm.herald.View');
+goog.require('olgm.herald.WMTSSource');
 goog.require('olgm.layer.Google');
 
 
@@ -78,6 +79,12 @@ olgm.herald.Layers = function(ol3map, gmap, watchVector) {
    * @private
    */
   this.vectorSourceHerald_ = new olgm.herald.VectorSource(ol3map, gmap);
+
+  /**
+   * @type {olgm.herald.WMTSSource}
+   * @private
+   */
+  this.wmtsSourceHerald_ = new olgm.herald.WMTSSource(ol3map, gmap);
 
   /**
    * @type {olgm.herald.View}
@@ -201,6 +208,7 @@ olgm.herald.Layers.prototype.setGoogleMapsActive_ = function(active) {
   this.imageWMSSourceHerald_.setGoogleMapsActive(active);
   this.tileWMSSourceHerald_.setGoogleMapsActive(active);
   this.vectorSourceHerald_.setGoogleMapsActive(active);
+  this.wmtsSourceHerald_.setGoogleMapsActive(active);
 };
 
 
@@ -242,6 +250,8 @@ olgm.herald.Layers.prototype.watchLayer_ = function(layer) {
     var source = layer.getSource();
     if (source instanceof ol.source.TileWMS) {
       this.tileWMSSourceHerald_.watchLayer(layer);
+    } else if (source instanceof ol.source.WMTS) {
+      this.wmtsSourceHerald_.watchLayer(layer);
     }
   } else if (layer instanceof ol.layer.Image) {
     var source = layer.getSource();
@@ -283,6 +293,8 @@ olgm.herald.Layers.prototype.unwatchLayer_ = function(layer) {
     var source = layer.getSource();
     if (source instanceof ol.source.TileWMS) {
       this.tileWMSSourceHerald_.unwatchLayer(layer);
+    } else if (source instanceof ol.source.WMTS) {
+      this.wmtsSourceHerald_.unwatchLayer(layer);
     }
   } else if (layer instanceof ol.layer.Image) {
     var source = layer.getSource();
@@ -348,6 +360,7 @@ olgm.herald.Layers.prototype.activateGoogleMaps_ = function() {
   this.tileWMSSourceHerald_.activate();
   this.imageWMSSourceHerald_.activate();
   this.vectorSourceHerald_.activate();
+  this.wmtsSourceHerald_.activate();
 };
 
 
@@ -375,6 +388,7 @@ olgm.herald.Layers.prototype.deactivateGoogleMaps_ = function() {
   this.tileWMSSourceHerald_.deactivate();
   this.imageWMSSourceHerald_.deactivate();
   this.vectorSourceHerald_.deactivate();
+  this.wmtsSourceHerald_.deactivate();
 
   this.setGoogleMapsActive_(false);
 };

--- a/src/herald/wmtssourceherald.js
+++ b/src/herald/wmtssourceherald.js
@@ -1,0 +1,200 @@
+goog.provide('olgm.herald.WMTSSource');
+
+goog.require('olgm.herald.Source');
+
+
+
+/**
+ * Listen to a WMTS layer
+ * @param {!ol.Map} ol3map
+ * @param {!google.maps.Map} gmap
+ * @constructor
+ * @extends {olgm.herald.Source}
+ */
+olgm.herald.WMTSSource = function(ol3map, gmap) {
+  /**
+  * @type {Array.<olgm.herald.WMTSSource.LayerCache>}
+  * @private
+  */
+  this.cache_ = [];
+
+  /**
+  * @type {Array.<ol.layer.Tile>}
+  * @private
+  */
+  this.layers_ = [];
+
+  goog.base(this, ol3map, gmap);
+};
+goog.inherits(olgm.herald.WMTSSource, olgm.herald.Source);
+
+
+/**
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.WMTSSource.prototype.watchLayer = function(layer) {
+  var tileLayer = /** {@type ol.layer.Tile} */ (layer);
+  goog.asserts.assertInstanceof(tileLayer, ol.layer.Tile);
+
+  // Source required
+  var source = tileLayer.getSource();
+  if (!source) {
+    return;
+  }
+  goog.asserts.assertInstanceof(source, ol.source.WMTS);
+  this.layers_.push(tileLayer);
+
+  // opacity
+  var opacity = tileLayer.getOpacity();
+
+  var cacheItem = /** {@type olgm.herald.WMTSSource.LayerCache} */ ({
+    layer: tileLayer,
+    listenerKeys: [],
+    opacity: opacity
+  });
+
+  var getTileUrlFunction = source.getTileUrlFunction();
+  var proj = ol.proj.get('EPSG:3857');
+
+  var googleGetTileUrlFunction = function(coords, zoom) {
+    var ol3Coords = [zoom, coords.x, (-coords.y) - 1];
+    return getTileUrlFunction(ol3Coords, 1, proj);
+  };
+
+  var tileSize = new google.maps.Size(256, 256);
+
+  var options = {
+    'getTileUrl': googleGetTileUrlFunction,
+    'tileSize': tileSize,
+    'isPng': true,
+    'opacity': opacity
+  };
+
+  // Create the WMTS layer on the google layer
+  var googleWMSLayer = new google.maps.ImageMapType(options);
+  if (tileLayer.getVisible()) {
+    this.gmap.overlayMapTypes.push(googleWMSLayer);
+  }
+  cacheItem.googleWMTSLayer = googleWMSLayer;
+
+  // Hide the google layer when the ol3 layer is invisible
+  cacheItem.listenerKeys.push(tileLayer.on('change:visible',
+      this.handleVisibleChange_.bind(this, cacheItem), this));
+
+  // Activate the cache item
+  this.activateCacheItem_(cacheItem);
+  this.cache_.push(cacheItem);
+};
+
+
+/**
+ * Unwatch the WMS tile layer
+ * @param {ol.layer.Base} layer
+ * @override
+ */
+olgm.herald.WMTSSource.prototype.unwatchLayer = function(layer) {
+  var tileLayer = /** {@type ol.layer.Tile} */ (layer);
+  goog.asserts.assertInstanceof(tileLayer, ol.layer.Tile);
+
+  var index = this.layers_.indexOf(tileLayer);
+  if (index !== -1) {
+    this.layers_.splice(index, 1);
+
+    var cacheItem = this.cache_[index];
+    olgm.unlistenAllByKey(cacheItem.listenerKeys);
+
+    // opacity
+    tileLayer.setOpacity(cacheItem.opacity);
+
+    this.cache_.splice(index, 1);
+  }
+};
+
+
+/**
+ * Activate all cache items
+ * @api
+ */
+olgm.herald.WMTSSource.prototype.activate = function() {
+  olgm.herald.WMTSSource.base(this, 'activate'); // Call parent function
+  this.cache_.forEach(this.activateCacheItem_, this);
+};
+
+
+/**
+ * Activates an image WMS layer cache item.
+ * @param {olgm.herald.WMTSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.WMTSSource.prototype.activateCacheItem_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+  if (visible && this.googleMapsIsActive) {
+    cacheItem.layer.setOpacity(0);
+  }
+};
+
+
+/**
+ * Deactivate all cache items
+ * @api
+ */
+olgm.herald.WMTSSource.prototype.deactivate = function() {
+  olgm.herald.WMTSSource.base(this, 'deactivate'); //Call parent function
+  this.cache_.forEach(this.deactivateCacheItem_, this);
+};
+
+
+/**
+ * Deactivates a Tile WMS layer cache item.
+ * @param {olgm.herald.WMTSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.WMTSSource.prototype.deactivateCacheItem_ = function(
+    cacheItem) {
+  cacheItem.layer.setOpacity(cacheItem.opacity);
+};
+
+
+/**
+ * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
+ * @param {olgm.herald.WMTSSource.LayerCache} cacheItem
+ * @private
+ */
+olgm.herald.WMTSSource.prototype.handleVisibleChange_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+  var visible = layer.getVisible();
+
+  var googleWMTSLayer = cacheItem.googleWMTSLayer;
+  var googleMapsLayers = this.gmap.overlayMapTypes;
+
+  // Get the position of the google layer so we can remove it
+  var layerIndex = googleMapsLayers.getArray().indexOf(googleWMTSLayer);
+
+  if (visible) {
+    // Add the google WMTS layer only if it's not there already
+    if (layerIndex == -1) {
+      googleMapsLayers.push(googleWMTSLayer);
+    }
+    this.activateCacheItem_(cacheItem);
+  } else {
+    // Remove the google WMTS layer from the map if it hasn't been done already
+    if (layerIndex != -1) {
+      googleMapsLayers.removeAt(layerIndex);
+    }
+    this.deactivateCacheItem_(cacheItem);
+  }
+};
+
+
+/**
+ * @typedef {{
+ *   layer: (ol.layer.Tile),
+ *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   opacity: (number)
+ * }}
+ */
+olgm.herald.WMTSSource.LayerCache;

--- a/src/herald/wmtssourceherald.js
+++ b/src/herald/wmtssourceherald.js
@@ -192,6 +192,7 @@ olgm.herald.WMTSSource.prototype.handleVisibleChange_ = function(
 
 /**
  * @typedef {{
+ *   googleWMTSLayer: (google.maps.ImageMapType),
  *   layer: (ol.layer.Tile),
  *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
  *   opacity: (number)

--- a/src/herald/wmtssourceherald.js
+++ b/src/herald/wmtssourceherald.js
@@ -72,11 +72,11 @@ olgm.herald.WMTSSource.prototype.watchLayer = function(layer) {
   };
 
   // Create the WMTS layer on the google layer
-  var googleWMSLayer = new google.maps.ImageMapType(options);
+  var googleWMTSLayer = new google.maps.ImageMapType(options);
   if (tileLayer.getVisible()) {
-    this.gmap.overlayMapTypes.push(googleWMSLayer);
+    this.gmap.overlayMapTypes.push(googleWMTSLayer);
   }
-  cacheItem.googleWMTSLayer = googleWMSLayer;
+  cacheItem.googleWMTSLayer = googleWMTSLayer;
 
   // Hide the google layer when the ol3 layer is invisible
   cacheItem.listenerKeys.push(tileLayer.on('change:visible',
@@ -89,7 +89,7 @@ olgm.herald.WMTSSource.prototype.watchLayer = function(layer) {
 
 
 /**
- * Unwatch the WMS tile layer
+ * Unwatch the WMTS tile layer
  * @param {ol.layer.Base} layer
  * @override
  */
@@ -123,7 +123,7 @@ olgm.herald.WMTSSource.prototype.activate = function() {
 
 
 /**
- * Activates an image WMS layer cache item.
+ * Activates an image WMTS layer cache item.
  * @param {olgm.herald.WMTSSource.LayerCache} cacheItem
  * @private
  */
@@ -148,7 +148,7 @@ olgm.herald.WMTSSource.prototype.deactivate = function() {
 
 
 /**
- * Deactivates a Tile WMS layer cache item.
+ * Deactivates a Tile WMTS layer cache item.
  * @param {olgm.herald.WMTSSource.LayerCache} cacheItem
  * @private
  */
@@ -159,7 +159,7 @@ olgm.herald.WMTSSource.prototype.deactivateCacheItem_ = function(
 
 
 /**
- * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
+ * Deal with the google WMTS layer when we enable or disable the OL3 WMTS layer
  * @param {olgm.herald.WMTSSource.LayerCache} cacheItem
  * @private
  */


### PR DESCRIPTION
This patch adds support for WMTS layers in OL3-Google-Maps, as well as an example, mostly taken from [here](http://openlayers.org/en/latest/examples/wmts.html). The code is very similar to the one for tiled WMS layers.
