### PR TITLE
Add examples for different tile layer types

### DIFF
--- a/examples/resources/layout.css
+++ b/examples/resources/layout.css
@@ -28,3 +28,7 @@ input {
 legend {
   margin: 0;
 }
+
+td {
+  padding: 5px;
+}

--- a/examples/tiles.html
+++ b/examples/tiles.html
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps WMTS example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Tiles example</h4>
+          <p>
+            Shows different tile layers displayed on google maps. Note: the
+            layers are displayed in the order that you enable them.
+          </p>
+
+          <input id="toggleOSM" type="button" onclick="toggleOSM();"
+                       value="Toggle between OL3 and GMAPS" />
+          <table>
+            <tr>
+              <td>
+                <input type="checkbox" onclick="toggleLayer(0, this.checked);">
+                  TileJSON
+                </input>
+              </td>
+              <td>
+                <input type="checkbox" onclick="toggleLayer(1, this.checked);">
+                  TMS
+                </input>
+              </td>
+              <td>
+                <input type="checkbox" onclick="toggleLayer(2, this.checked);">
+                  WMS
+                </input>
+              </td>
+              <td>
+                <input type="checkbox" onclick="toggleLayer(3, this.checked);">
+                  WMTS
+                </input>
+              </td>
+              <td>
+                <input type="checkbox" onclick="toggleLayer(4, this.checked);">
+                  XYZ
+                </input>
+              </td>
+            <tr>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+
+    <script src="/@loader"></script>
+    <script src="tiles.js"></script>
+  </body>
+</html>

--- a/examples/tiles.js
+++ b/examples/tiles.js
@@ -1,0 +1,105 @@
+var center = [-10997148, 4569099];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var tileJSONLayer = new ol.layer.Tile({
+  source: new ol.source.TileJSON({
+    url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
+    crossOrigin: 'anonymous'
+  }),
+  opacity: 0.5,
+});
+
+var tmsLayer = new ol.layer.Tile({
+  source: new ol.source.XYZ({
+    url: 'http://v3.cartalib.mapgears.com/mapcache/tms/' +
+        '1.0.0/mapgears_basemap@g/{z}/{x}/{-y}.'
+  }),
+});
+
+// Setup tilegrid for wmts layer
+var projection = ol.proj.get('EPSG:3857');
+var projectionExtent = projection.getExtent();
+var size = ol.extent.getWidth(projectionExtent) / 256;
+var resolutions = new Array(14);
+var matrixIds = new Array(14);
+for (var z = 0; z < 14; ++z) {
+  // generate resolutions and matrixIds arrays for this WMTS
+  resolutions[z] = size / Math.pow(2, z);
+  matrixIds[z] = z;
+}
+
+var wmsLayer = new ol.layer.Tile({
+  extent: [-13884991, 2870341, -7455066, 6338219],
+  source: new ol.source.TileWMS({
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    params: {'LAYERS': 'topp:states', 'TILED': true},
+    serverType: 'geoserver'
+  }),
+});
+
+var wmtsLayer = new ol.layer.Tile({
+  opacity: 0.7,
+  source: new ol.source.WMTS({
+    attributions: '' +
+        'Tiles © <a href="http://services.arcgisonline.com/arcgis/rest/' +
+        'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>',
+    url: 'http://services.arcgisonline.com/arcgis/rest/' +
+        'services/Demographics/USA_Population_Density/MapServer/WMTS/',
+    layer: '0',
+    matrixSet: 'EPSG:3857',
+    format: 'image/png',
+    projection: projection,
+    tileGrid: new ol.tilegrid.WMTS({
+      origin: ol.extent.getTopLeft(projectionExtent),
+      resolutions: resolutions,
+      matrixIds: matrixIds
+    }),
+    style: 'default',
+    wrapX: true
+  }),
+});
+
+var xyzLayer = new ol.layer.Tile({
+  source: new ol.source.XYZ({
+    url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
+  }),
+  opacity: 1,
+});
+
+var togglableLayers = [tileJSONLayer, tmsLayer, wmsLayer, wmtsLayer, xyzLayer];
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+function toggleOSM() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};
+
+function toggleLayer(index, value) {
+  if (value) {
+    map.addLayer(togglableLayers[index]);
+  } else {
+    map.removeLayer(togglableLayers[index]);
+  }
+}

--- a/examples/tms.html
+++ b/examples/tms.html
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps TMS example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>TMS example</h4>
+          <p>
+            Shows that TMS layers added to OL3 are ported to Google Maps
+            when the latter gets activated. Note: OL3 doesn't actually support
+            TMS layers. Instead, we use the XYZ layer source with an inverted
+            y coordinate.
+          </p>
+
+          <input id="toggleOSM" type="button" onclick="toggleOSM();"
+                 value="Toggle between OL3 and GMAPS" />
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+
+    <script src="/@loader"></script>
+    <script src="tms.js"></script>
+  </body>
+</html>

--- a/examples/tms.js
+++ b/examples/tms.js
@@ -9,7 +9,8 @@ var osmLayer = new ol.layer.Tile({
 
 var tmsLayer = new ol.layer.Tile({
   source: new ol.source.XYZ({
-    url: 'http://v3.cartalib.mapgears.com/mapcache/tms/1.0.0/mapgears_basemap@g/{z}/{x}/{-y}.'
+    url: 'http://v3.cartalib.mapgears.com/mapcache/tms/1.0.0/' +
+        'mapgears_basemap@g/{z}/{x}/{-y}.'
   }),
   opacity: 1
 });

--- a/examples/tms.js
+++ b/examples/tms.js
@@ -1,0 +1,38 @@
+var center = [-10997148, 4569099];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var tmsLayer = new ol.layer.Tile({
+  source: new ol.source.XYZ({
+    url: 'http://v3.cartalib.mapgears.com/mapcache/tms/1.0.0/mapgears_basemap@g/{z}/{x}/{-y}.'
+  }),
+  opacity: 1
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    tmsLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+function toggleOSM() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -61,7 +61,16 @@ olgm.herald.TileSource.prototype.watchLayer = function(layer) {
 
   var googleGetTileUrlFunction = function(coords, zoom) {
     var ol3Coords = [zoom, coords.x, (-coords.y) - 1];
-    return getTileUrlFunction(ol3Coords, 1, proj);
+    var result = getTileUrlFunction(ol3Coords, 1, proj);
+
+    // TileJSON sources don't have their url function right away, try again
+    if (result === undefined) {
+      goog.asserts.assertInstanceof(source, ol.source.TileImage);
+      getTileUrlFunction = source.getTileUrlFunction();
+      result = getTileUrlFunction(ol3Coords, 1, proj);
+    }
+
+    return result;
   };
 
   var tileSize = new google.maps.Size(256, 256);


### PR DESCRIPTION
This commits adds one example for TMS layers and one example that combines the following layer types:
- TileJSON
- TMS
- WMS
- WMTS
- XYZ

However, I noticed a new issue while testing these layers: most of them can't handle negative coordinates, which is what google receives for the tiles outside the world limit. This means we send invalid requests when we're zoomed out far enough. I intend to open a ticket about it when this PR gets through.
