### PR TITLE
Improve procedure for building examples

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -34,8 +34,8 @@ The usage of `make` is as follows:
 
     $ make <target>
 
-The main build targets are `serve`, `lint`, `dist` and `check`. The
-latter is a meta-target that basically runs `lint` and `dist`.
+The main build targets are `serve`, `lint`, `dist`, 'dist-examples' and
+`check`. The latter is a meta-target that basically runs `lint` and `dist`.
 
 The examples can be built for deployment with the `dist-examples` build target.
 An optional `API_KEY` parameter can be provided:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -37,6 +37,13 @@ The usage of `make` is as follows:
 The main build targets are `serve`, `lint`, `dist` and `check`. The
 latter is a meta-target that basically runs `lint` and `dist`.
 
+The examples can be built for deployment with the `dist-examples` build target.
+An optional `API_KEY` parameter can be provided:
+
+    $ make [API_KEY=<key>] dist-examples
+
+This will replace the Google Maps API key in the examples for the one provided.
+
 
 ## Running the `check` target
 
@@ -55,3 +62,5 @@ To run the examples you first need to start the dev server:
     $ make serve
 
 Then, just point your browser <http://localhost:3000/examples> in your browser.
+
+To build the examples for deployment, use the `dist-examples` build target.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -34,7 +34,7 @@ The usage of `make` is as follows:
 
     $ make <target>
 
-The main build targets are `serve`, `lint`, `dist`, 'dist-examples' and
+The main build targets are `serve`, `lint`, `dist`, `dist-examples` and
 `check`. The latter is a meta-target that basically runs `lint` and `dist`.
 
 The examples can be built for deployment with the `dist-examples` build target.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ifeq ($(shell uname),Darwin)
 else
 	SEDI := $(shell which sed) -i
 endif
+API_KEY ?= AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ
 UNAME := $(shell uname)
 SRC_JS_FILES := $(shell find src -type f -name '*.js')
 EXAMPLES_JS_FILES := $(shell find examples -type f -name '*.js')
@@ -84,7 +85,15 @@ cleanall: clean
 	node build/parse-examples.js
 	mkdir -p $(dir $@)
 	cp -R examples dist/
-	for f in dist/examples/*.html; do $(SEDI) 'sY/@loaderY../ol3gm.jsY' $$f; done
+	cp node_modules/openlayers/css/ol.css dist/examples/resources/ol.css
+	cp css/ol3gm.css dist/examples/resources/ol3gm.css
+	for f in dist/examples/*.html; do \
+		$(SEDI) 's|/@loader|../ol3gm.js|' $$f ; \
+		$(SEDI) 's|<script.*build/ol\.js.*script>||' $$f; \
+		$(SEDI) 's|AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ|$(API_KEY)|' $$f; \
+		$(SEDI) 's|../node_modules/openlayers/css/ol.css|resources/ol.css|' $$f ; \
+		$(SEDI) 's|../css/ol3gm.css|resources/ol3gm.css|' $$f ; \
+	done
 	touch $@
 
 .build/python-venv:


### PR DESCRIPTION
This commit adds a few improvements to the Makefile, specifically to the make dist-examples command. First, the script tags containing a link to the ol library are removed. They are no longer necessary as ol3 is compiled with ol3gm.

Second, the css file for openlayers located at `node_modules/openlayers/css/ol.css` is copied to the examples folder, and the  paths are updated in the HTML files.

The same thing is done for `css/ol3gm.css`

Finally, the api key can now be sent as a parameter when building examples. To do this, we assume the key already entered in the HTML document is the key for 127.0.0.1. We look for it and replace it with the variable defined in API_KEY, which has the key for 127.0.0.1 as its default value.

For example, output of `make API_KEY=AIzaSyCXIGZ41A54812NVcfTIuFS2mQUK-9JYeg dist-examples`:

`<script type="text/javascript"
    src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyCXIGZ41A54812NVcfTIuFS2mQUK-9JYeg"></script>`

Output for `make dist-examples`:

`<script type="text/javascript"
    src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>`
