### PR TITLE
Remove API key from examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ cleanall: clean
 	for f in dist/examples/*.html; do \
 		$(SEDI) 's|/@loader|../ol3gm.js|' $$f ; \
 		$(SEDI) 's|<script.*build/ol\.js.*script>||' $$f; \
-		$(SEDI) 's|AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ|$(API_KEY)|' $$f; \
+		$(SEDI) 's|src="https://maps.googleapis.com/maps/api/js?v=3.21|src="https://maps.googleapis.com/maps/api/js?v=3.21\&key=$(API_KEY)|' $$f; \
+		$(SEDI) 's|outside of localhost|on your own server|' $$f; \
 		$(SEDI) 's|../node_modules/openlayers/css/ol.css|resources/ol.css|' $$f ; \
 		$(SEDI) 's|../css/ol3gm.css|resources/ol3gm.css|' $$f ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ cleanall: clean
 		$(SEDI) 's|/@loader|../ol3gm.js|' $$f ; \
 		$(SEDI) 's|<script.*build/ol\.js.*script>||' $$f; \
 		$(SEDI) 's|src="https://maps.googleapis.com/maps/api/js?v=3.21|src="https://maps.googleapis.com/maps/api/js?v=3.21\&key=$(API_KEY)|' $$f; \
+		$(SEDI) 's|src="https://maps.googleapis.com/maps/api/js"|src="https://maps.googleapis.com/maps/api/js?key=$(API_KEY)"|' $$f; \
 		$(SEDI) 's|outside of localhost|on your own server|' $$f; \
 		$(SEDI) 's|../node_modules/openlayers/css/ol.css|resources/ol.css|' $$f ; \
 		$(SEDI) 's|../css/ol3gm.css|resources/ol3gm.css|' $$f ; \

--- a/examples/concept.html
+++ b/examples/concept.html
@@ -52,7 +52,7 @@
                 <h5>Add Layer:</h5>
                 <input id="gm-add-sat" type="button" value="+ Satellite"
                        title="Adds a new olgm.layer.Google with map type id equal to 'satellite', which is immediately added to the gmap map."/>
-                <input id="gm-add-ter" type="button" value="+ Terrain" 
+                <input id="gm-add-ter" type="button" value="+ Terrain"
                        title="Adds a new olgm.layer.Google with map type id equal to 'terrain', which is immediately added to the gmap map."/>
 
                 <h5>Remove Layer:</h5>
@@ -91,12 +91,11 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- local -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-    <!-- dev5 -->
-    <!--script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyCXIGZ41A54812NVcfTIuFS2mQUK-9JYeg"></script-->
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
 
     <script src="/@loader"></script>
     <script src="concept.js"></script>

--- a/examples/icon.html
+++ b/examples/icon.html
@@ -39,7 +39,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="icon.js"></script>
   </body>

--- a/examples/icon.html
+++ b/examples/icon.html
@@ -34,10 +34,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="icon.js"></script>
   </body>

--- a/examples/label.html
+++ b/examples/label.html
@@ -45,7 +45,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="label.js"></script>
   </body>

--- a/examples/label.html
+++ b/examples/label.html
@@ -40,10 +40,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="label.js"></script>
   </body>

--- a/examples/latest.html
+++ b/examples/latest.html
@@ -40,7 +40,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="latest.js"></script>
   </body>

--- a/examples/latest.html
+++ b/examples/latest.html
@@ -35,10 +35,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="latest.js"></script>
   </body>

--- a/examples/latest.html
+++ b/examples/latest.html
@@ -39,7 +39,7 @@
          https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            src="https://maps.googleapis.com/maps/api/js"></script>
 
     <script src="/@loader"></script>
     <script src="latest.js"></script>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -42,7 +42,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="simple.js"></script>
   </body>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -37,10 +37,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="simple.js"></script>
   </body>

--- a/examples/themed.html
+++ b/examples/themed.html
@@ -39,7 +39,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="themed.js"></script>
   </body>

--- a/examples/themed.html
+++ b/examples/themed.html
@@ -34,10 +34,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="themed.js"></script>
   </body>

--- a/examples/tiles.html
+++ b/examples/tiles.html
@@ -62,10 +62,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="tiles.js"></script>
   </body>

--- a/examples/tiles.html
+++ b/examples/tiles.html
@@ -67,7 +67,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="tiles.js"></script>
   </body>

--- a/examples/tms.html
+++ b/examples/tms.html
@@ -35,10 +35,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="tms.js"></script>
   </body>

--- a/examples/tms.html
+++ b/examples/tms.html
@@ -40,7 +40,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="tms.js"></script>
   </body>

--- a/examples/traffic.html
+++ b/examples/traffic.html
@@ -37,7 +37,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="traffic.js"></script>
   </body>

--- a/examples/traffic.html
+++ b/examples/traffic.html
@@ -32,10 +32,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="traffic.js"></script>
   </body>

--- a/examples/vector.html
+++ b/examples/vector.html
@@ -45,7 +45,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="vector.js"></script>
   </body>

--- a/examples/vector.html
+++ b/examples/vector.html
@@ -40,10 +40,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="vector.js"></script>
   </body>

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -42,7 +42,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="wms.js"></script>
   </body>

--- a/examples/wms.html
+++ b/examples/wms.html
@@ -37,10 +37,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="wms.js"></script>
   </body>

--- a/examples/wmts.html
+++ b/examples/wmts.html
@@ -38,7 +38,7 @@
          where mykey is your Google Maps API key -->
     <script type="text/javascript"
             src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
-            
+
     <script src="/@loader"></script>
     <script src="wmts.js"></script>
   </body>

--- a/examples/wmts.html
+++ b/examples/wmts.html
@@ -33,10 +33,12 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
-
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
+            
     <script src="/@loader"></script>
     <script src="wmts.js"></script>
   </body>

--- a/examples/xyz.html
+++ b/examples/xyz.html
@@ -33,9 +33,11 @@
 
     <script src="../node_modules/openlayers/build/ol.js"></script>
 
-    <!-- GoogleMaps API Key for 127.0.0.1 -->
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3.21&key=mykey
+         where mykey is your Google Maps API key -->
     <script type="text/javascript"
-            src="https://maps.googleapis.com/maps/api/js?v=3.21&key=AIzaSyD71KlyTCXJouZsGbgPCJ-oCtK76fZJUTQ"></script>
+            src="https://maps.googleapis.com/maps/api/js?v=3.21"></script>
 
     <script src="/@loader"></script>
     <script src="xyz.js"></script>


### PR DESCRIPTION
Google Maps no longer requires an API key when loading the script, although it is recommended for production. We don't want users using our own API key so this commit removes it and adds a comment suggesting to add their own. The examples still work fine if they don't.
