### PR TITLE
Added Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 dist
 node_modules
 examples/example-list.js
+_site
 build/jsdoc/info/conf-generated.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 dist
 node_modules
 examples/example-list.js
-_site
+build/jsdoc/info/conf-generated.json

--- a/DEVELOPING-WINDOWS.md
+++ b/DEVELOPING-WINDOWS.md
@@ -1,0 +1,39 @@
+# Developing on Windows
+
+## Recommended tools for development
+These tools are recommended when developing on Windows:
+* Cygwin with:
+    * Python 2.6 or 2.7
+    * Make
+* Git Bash
+
+### Development dependencies
+
+The minimum requirements are:
+
+* GNU Make
+* Git
+* [Node.js](http://nodejs.org/) (4.2.x or higher)
+* Python 2.6 or 2.7
+* Java 7 (JRE and JDK)
+
+The executables `git`, `node`, and `java` should be in your `PATH`.
+
+Install pip through Cygwin:
+
+    $ easy_install-a.b pip
+ 
+Where a.b is either 2.6 or 2.7 depending on the chosen Python version.
+
+Also, through Cygwin, install virtualenv:
+    
+    $ pip install virtualenv
+
+To install the Node.js dependencies run
+
+    $ npm install
+
+
+## Working with the build tool on Windows
+Should work as described in DEVELOPING.md.
+

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,17 @@ EXAMPLES_JS_FILES := $(shell find examples -type f -name '*.js')
 EXAMPLES_HTML_FILES := $(shell find examples -type f -name '*.html')
 EXAMPLES_GEOJSON_FILES := $(shell find examples/data/ -name '*.geojson')
 
+ifeq ($(OS),Windows_NT)
+LINT_COMMAND := .build/python-venv/Scripts/gjslint.exe
+else
+LINT_COMMAND := .build/python-venv/bin/gjslint
+endif
+
+ifeq ($(OS),Windows_NT)
+PIP_COMMAND := .build/python-venv/Scripts/pip.exe
+else
+PIP_COMMAND := .build/python-venv/bin/pip
+endif
 
 .PHONY: all
 all: help
@@ -78,7 +89,7 @@ cleanall: clean
 	touch $@
 
 .build/gjslint.timestamp: $(SRC_JS_FILES)
-	.build/python-venv/bin/gjslint --jslint_error=all --strict --custom_jsdoc_tags=api $?
+	$(LINT_COMMAND) --jslint_error=all --strict --custom_jsdoc_tags=api $?
 	touch $@
 
 .build/dist-examples.timestamp: node_modules/openlayers/build/olX dist/ol3gm.js $(EXAMPLES_JS_FILES) $(EXAMPLES_HTML_FILES)
@@ -103,7 +114,7 @@ cleanall: clean
 	virtualenv --no-site-packages $@
 
 .build/python-venv/bin/gjslint: .build/python-venv
-	.build/python-venv/bin/pip install "http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
+	$(PIP_COMMAND) install "http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
 	touch $@
 
 dist/ol3gm-debug.js: build/ol3gm-debug.json $(SRC_JS_FILES) build/build.js npm-install

--- a/build/generate-info.js
+++ b/build/generate-info.js
@@ -12,7 +12,13 @@ var sourceDirs = [sourceDirOL, sourceDirSelf];
 var infoPath = path.join(__dirname, '..', '.build', 'info.json');
 var jsdoc = path.join(__dirname, '..', 'node_modules', '.bin', 'jsdoc');
 var jsdocConfig = path.join(__dirname, 'jsdoc', 'info', 'conf.json');
+var jsdocConfigGen = path.join(__dirname, '..', 'build', 'jsdoc', 'info', 'conf-generated.json');
 
+var platformWindows = process.platform.indexOf('win') === 0;
+
+if(platformWindows) {
+  jsdoc += '.cmd';
+}
 
 /**
  * Get the mtime of the info file.
@@ -91,7 +97,16 @@ function spawnJSDoc(paths, callback) {
   var output = '';
   var errors = '';
   var cwd = path.join(__dirname, '..');
-  var child = spawn(jsdoc, ['-c', jsdocConfig].concat(paths), {cwd: cwd});
+  var child;
+
+  if(platformWindows) {
+    var confObj = fse.readJsonSync(jsdocConfig);
+    confObj.source.include = paths;
+    fse.writeJsonSync(jsdocConfigGen, confObj);
+    child = spawn(jsdoc, ['-c', jsdocConfigGen]);
+  } else {
+    child = spawn(jsdoc, ['-c', jsdocConfig].concat(paths), {cwd: cwd});
+  }
 
   child.stdout.on('data', function(data) {
     output += String(data);


### PR DESCRIPTION
Building on Windows will generate a file called conf-generated.json in build/jsdoc/info/, as the command line does not handle all the paths passed to it:

``` bash
mkdir -p .build/
touch .build/node_modules.timestamp
mkdir -p dist/
node build/build.js build/ol3gm.json dist/ol3gm.js
ERR! Trouble generating info: The command line is too long.

Makefile:120: recipe for target 'dist/ol3gm.js' failed
make: *** [dist/ol3gm.js] Error 1
```

As it simply copies and adds to the conf.json file, the conf-generated.json is added to .gitignore. The code is greatly inspired by the discussion found [here](https://www.bountysource.com/issues/2283601-building-ol-3-since-beta-5-on-windows?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github) and the implementation done by the [OL3 team.](https://github.com/openlayers/ol3/blob/master/tasks/generate-info.js) Tested on both Linux and Windows, works fine.
