### PR TITLE
Update task scripts

### DIFF
--- a/tasks/changelog.sh
+++ b/tasks/changelog.sh
@@ -11,6 +11,9 @@ set -o errexit
 #
 MERGE_RE=Merge\ pull\ request\ #\([0-9]+\)\ from\ \([^/]+\)\/[^\ ]+\ \(.*\)
 
+# Squash commits have a different format
+SQUASH_RE='([^\|]+)\|([^\(]+) \(#([0-9]+)\)'
+
 GITHUB_URL=https://github.com
 PULLS_URL=${GITHUB_URL}/mapgears/ol3-google-maps/pull
 
@@ -35,7 +38,7 @@ EOF
 # branch (instead only showing merges to master).
 #
 main() {
-  git log --first-parent --format='%s %b' ${1} |
+  git log --first-parent --format='%aN|%s %b' ${1} |
   {
     while read l; do
       if [[ ${l} =~ ${MERGE_RE} ]] ; then
@@ -43,6 +46,11 @@ main() {
         author="${BASH_REMATCH[2]}"
         summary="${BASH_REMATCH[3]}"
         echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([@${author}](${GITHUB_URL}/${author}))"
+      elif [[ ${l} =~ ${SQUASH_RE} ]] ; then
+        number="${BASH_REMATCH[3]}"
+        author="${BASH_REMATCH[1]}"
+        summary="${BASH_REMATCH[2]}"
+        echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([${author}](${GITHUB_URL}/search?q=${author}&type=Users))"
       fi
     done
   }

--- a/tasks/package.sh
+++ b/tasks/package.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# cd to script directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+# 1==zip, 0==tgz
+zip=1
+
+PREFIX="ol3-google-maps"
+#PREFIX=""
+
+#VERSION="dev"
+
+dirname=""
+
+if [ $# != 1 ];
+then
+    echo "Usage: package.sh <version>"
+    exit 1
+fi
+
+VERSION=$1
+
+if [ "$PREFIX" != "" ];
+then
+    dirname+=$PREFIX
+fi
+
+if [ "$VERSION" != "" ];
+then
+    if [ "$dirname" != "" ];
+    then
+        dirname+="-"
+    fi
+    dirname+=$VERSION
+fi
+
+
+mkdir $dirname
+cp ../dist/ol3gm-debug.js $dirname
+cp ../dist/ol3gm.js $dirname
+cp ../css/ol3gm.css $dirname
+
+if [ "$zip" == "1" ];
+then
+    filename=$dirname".zip"
+    zip -r $filename $dirname
+else
+    filename=$dirname".tar.gz"
+    tar czf $filename $dirname
+fi
+
+rm -rf $dirname

--- a/tasks/package.sh
+++ b/tasks/package.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # cd to script directory
+DEST_DIR=$(pwd)
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
@@ -50,5 +51,7 @@ else
     filename=$dirname".tar.gz"
     tar czf $filename $dirname
 fi
+
+mv $filename $DEST_DIR
 
 rm -rf $dirname

--- a/tasks/package.sh
+++ b/tasks/package.sh
@@ -1,57 +1,36 @@
 #!/bin/bash
 
-# cd to script directory
+# save current directory cd to script directory
 DEST_DIR=$(pwd)
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-# 1==zip, 0==tgz
-zip=1
-
 PREFIX="ol3-google-maps"
-#PREFIX=""
-
-#VERSION="dev"
-
 dirname=""
 
+# Check for appropriate usage of the command
 if [ $# != 1 ];
 then
     echo "Usage: package.sh <version>"
     exit 1
 fi
 
+# Build the file name
 VERSION=$1
+dirname+=$PREFIX
+dirname+="-"
+dirname+=$VERSION
 
-if [ "$PREFIX" != "" ];
-then
-    dirname+=$PREFIX
-fi
-
-if [ "$VERSION" != "" ];
-then
-    if [ "$dirname" != "" ];
-    then
-        dirname+="-"
-    fi
-    dirname+=$VERSION
-fi
-
-
+# Create a folder containing the appropriate files
 mkdir $dirname
 cp ../dist/ol3gm-debug.js $dirname
 cp ../dist/ol3gm.js $dirname
 cp ../css/ol3gm.css $dirname
 
-if [ "$zip" == "1" ];
-then
-    filename=$dirname".zip"
-    zip -r $filename $dirname
-else
-    filename=$dirname".tar.gz"
-    tar czf $filename $dirname
-fi
+# Zip the folder
+filename=$dirname".zip"
+zip -r $filename $dirname
 
+# Clean up
 mv $filename $DEST_DIR
-
 rm -rf $dirname


### PR DESCRIPTION
This commit adds a package.sh script to the tasks folder. This script is used as follows:
`package.sh <version>`
It creates a zip file containing the compiled library files.

The commit also updates the `changelog.sh` script to support squash commits. The code for that was taken from [OpenLayers' changelog script](https://github.com/openlayers/ol3/blob/master/tasks/changelog.sh).
