### PR TITLE
Ask for Google Maps API key when serving examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.build
-dist
-node_modules
-examples/example-list.js
 _site
+.build
+api_key.txt
 build/jsdoc/info/conf-generated.json
+dist
+examples/example-list.js
+node_modules

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -61,6 +61,24 @@ To run the examples you first need to start the dev server:
 
     $ make serve
 
+The first time you run this command, you will be asked for a Google Maps API
+key. If you don't already have one, follow the instructions on
+[this page](https://developers.google.com/maps/documentation/javascript/get-api-key)
+to create one.
+
 Then, just point your browser <http://localhost:3000/examples> in your browser.
 
 To build the examples for deployment, use the `dist-examples` build target.
+
+## Contributing
+
+To contribute to the project, create a branch tracking master and work from
+there. Feel free to create several small commits for each of your changes, they
+will be squashed into one commit when the branch is merged. When your fix is
+complete, create a pull request
+[here](https://github.com/mapgears/ol3-google-maps/pulls).
+
+When creating a commit for this project, do not include the modifications in
+the examples that involve changing the API key for your own. To revert these
+changes, you can run the script located in `tasks/resetkey.sh`. You can also
+choose which lines to add to a commit with the `git add -p <file>` command.

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ npm-install: .build/node_modules.timestamp
 
 .PHONY: serve
 serve: node_modules/openlayers/build/olX
+	./tasks/setkey.sh
 	node build/serve.js
 
 .PHONY: dist

--- a/tasks/resetkey.sh
+++ b/tasks/resetkey.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Get examples directory
+script_dir=$(dirname "$0")
+examples="$script_dir/../examples/*.html"
+
+original_url="\"https://maps.googleapis.com/maps/api/js?v=3\&key=.*\""
+modified_url="\"https://maps.googleapis.com/maps/api/js?v=3\""
+
+# Replace key in examples
+sed -i "s|$original_url|$modified_url|g" $examples
+echo "Examples keys restored"
+
+exit 0

--- a/tasks/setkey.sh
+++ b/tasks/setkey.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
-echo "Enter a Google Maps API Key for localhost, or press enter to skip: "
-read api_key
-
 # Get examples directory
 script_dir=$(dirname "$0")
 examples="$script_dir/../examples/*.html"
+key_file="$script_dir/../api_key.txt"
 
-# If length is too short, skip
-key_length=${#api_key}
+if [ ! -f $key_file ]; then
+    echo "Enter a Google Maps API Key for localhost, or press enter to skip: "
+    read api_key
 
-if [ $key_length -le 1 ] ; then
-    echo "Skipping key step (examples might not work)"
-    exit 0
+    # If length is too short, skip
+    key_length=${#api_key}
+
+    if [ $key_length -le 1 ] ; then
+        echo "Skipping key step (examples might not work)"
+        exit 0
+    fi
+
+    # Save key to file
+    echo $api_key > api_key.txt
+else
+    api_key=$(cat $key_file)
 fi
 
 original_url="\"https://maps.googleapis.com/maps/api/js?v=3\""

--- a/tasks/setkey.sh
+++ b/tasks/setkey.sh
@@ -11,7 +11,7 @@ examples="$script_dir/../examples/*.html"
 key_length=${#api_key}
 
 if [ $key_length -le 1 ] ; then
-    echo "Skipping key step (examples won't work)"
+    echo "Skipping key step (examples might not work)"
     exit 0
 fi
 

--- a/tasks/setkey.sh
+++ b/tasks/setkey.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Enter a Google Maps API Key for localhost, or press enter to skip: "
+read api_key
+
+# Get examples directory
+script_dir=$(dirname "$0")
+examples="$script_dir/../examples/*.html"
+
+# If length is too short, skip
+key_length=${#api_key}
+
+if [ $key_length -le 1 ] ; then
+    echo "Skipping key step (examples won't work)"
+    exit 0
+fi
+
+original_url="\"https://maps.googleapis.com/maps/api/js?v=3\""
+modified_url="\"https://maps.googleapis.com/maps/api/js?v=3\&key=$api_key\""
+
+# Replace key in examples
+sed -i "s|$original_url|$modified_url|g" $examples
+echo "Examples keys set"
+
+exit 0


### PR DESCRIPTION
Last Wednesday, Google Maps reverted the decision to no longer need an API key. It still works on pages that were accessed without an API key, but new ones won't work. This means our current examples still work but any new examples we create won't work on local builds.

This commit adds two scripts:
- `tasks/setkey` asks for an API key and sets it for every example in the examples folder
- `tasks/resetkey` reverts the changes made by the previous script.

The `setkey` script is now called when running `make serve`.
