### PR TITLE
Switch from jshint to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "extends": "openlayers",
+  "env": {
+    "jquery": true
+  },
+  "rules": {
+    "no-console": 0,
+    "semi": 2
+  },
+  "globals": {
+    "goog": false,
+    "google": false,
+    "ol": false
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   "globals": {
     "goog": false,
     "google": false,
-    "ol": false
+    "ol": false,
+    "olgm": false
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ dist-apidoc:
 	node node_modules/.bin/jsdoc -c build/jsdoc/api/conf.json -d dist/apidoc
 
 .PHONY: lint
-lint: .build/python-venv/bin/gjslint .build/gjslint.timestamp
+lint:
+	npm test
 
 .build/geojsonhint.timestamp: $(EXAMPLES_GEOJSON_FILES)
 	$(foreach file,$?, echo $(file); node_modules/geojsonhint/bin/geojsonhint $(file);)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "google maps"
   ],
   "homepage": "http://mapgears.github.io/ol3-google-maps/",
-  "scripts": {},
+  "scripts": {
+    "pretest": "eslint src/"
+  },
   "main": "dist/ol3gm.js",
   "repository": {
     "type": "git",
@@ -30,10 +32,11 @@
   "devDependencies": {
     "closure-util": "1.14.0",
     "geojsonhint": "^1.0.0",
+    "eslint": "2.8.0",
+    "eslint-config-openlayers": "4.1.0",
     "fs-extra": "~0.8.1",
     "graceful-fs": "~3.0.2",
     "jsdoc": "~3.4.0",
-    "jshint": "~2.5.1",
     "openlayers": "openlayers/ol3#v3.16.0",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -1,14 +1,13 @@
 goog.provide('olgm.Abstract');
 
 
-
 /**
  * Abstract class for most classes of this library, which receives a reference
  * to the `google.maps.Map` and `ol.Map` objects an behave accordingly with
  * them.
  *
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  */
 olgm.Abstract = function(ol3map, gmap) {

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -10,10 +10,10 @@ goog.require('olgm.gm.MapLabel');
 
 /**
  * Create a Google Maps feature using an OpenLayers one.
- * @param {ol.Feature} feature
+ * @param {ol.Feature} feature feature to create
  * @param {ol.Map=} opt_ol3map For reprojection purpose. If undefined, then
  *     `EPSG:3857` is used.
- * @return {google.maps.Data.Feature}
+ * @return {google.maps.Data.Feature} google Feature
  */
 olgm.gm.createFeature = function(feature, opt_ol3map) {
   var geometry = feature.getGeometry();
@@ -27,10 +27,11 @@ olgm.gm.createFeature = function(feature, opt_ol3map) {
 
 /**
  * Create a Google Maps geometry using an OpenLayers one.
- * @param {ol.geom.Geometry} geometry
+ * @param {ol.geom.Geometry} geometry geometry to create
  * @param {ol.Map=} opt_ol3map For reprojection purpose. If undefined, then
  *     `EPSG:3857` is used.
  * @return {google.maps.Data.Geometry|google.maps.LatLng|google.maps.LatLng}
+ * google Geometry or LatLng
  */
 olgm.gm.createFeatureGeometry = function(geometry, opt_ol3map) {
 
@@ -52,10 +53,10 @@ olgm.gm.createFeatureGeometry = function(geometry, opt_ol3map) {
 
 /**
  * Create a Google Maps LatLng object using an OpenLayers Point.
- * @param {ol.geom.Point|ol.Coordinate} object
+ * @param {ol.geom.Point|ol.Coordinate} object coordinate to create
  * @param {ol.Map=} opt_ol3map For reprojection purpose. If undefined, then
  *     `EPSG:3857` is used.
- * @return {google.maps.LatLng}
+ * @return {google.maps.LatLng} google LatLng object
  */
 olgm.gm.createLatLng = function(object, opt_ol3map) {
   var inProj = (opt_ol3map !== undefined) ?
@@ -73,10 +74,11 @@ olgm.gm.createLatLng = function(object, opt_ol3map) {
 
 /**
  * Create a Google Maps LineString or Polygon object using an OpenLayers one.
- * @param {ol.geom.LineString|ol.geom.Polygon} geometry
+ * @param {ol.geom.LineString|ol.geom.Polygon} geometry geometry to create
  * @param {ol.Map=} opt_ol3map For reprojection purpose. If undefined, then
  *     `EPSG:3857` is used.
- * @return {google.maps.Data.LineString|google.maps.Data.Polygon}
+ * @return {google.maps.Data.LineString|google.maps.Data.Polygon} google
+ * LineString or Polygon
  */
 olgm.gm.createGeometry = function(geometry, opt_ol3map) {
   var inProj = (opt_ol3map !== undefined) ?
@@ -113,9 +115,10 @@ olgm.gm.createGeometry = function(geometry, opt_ol3map) {
 
 /**
  * Create a Google Maps data style options from an OpenLayers object.
- * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature} object
- * @param {number=} opt_index
- * @return {?google.maps.Data.StyleOptions}
+ * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature}
+ * object style object
+ * @param {number=} opt_index index for the object
+ * @return {?google.maps.Data.StyleOptions} google style options
  */
 olgm.gm.createStyle = function(object, opt_index) {
   var gmStyle = null;
@@ -129,9 +132,9 @@ olgm.gm.createStyle = function(object, opt_index) {
 
 /**
  * Create a Google Maps data style options from an OpenLayers style object.
- * @param {ol.style.Style} style
- * @param {number=} opt_index
- * @return {google.maps.Data.StyleOptions}
+ * @param {ol.style.Style} style style object
+ * @param {number=} opt_index index for the object
+ * @return {google.maps.Data.StyleOptions} google style options
  */
 olgm.gm.createStyleInternal = function(style, opt_index) {
 
@@ -277,10 +280,10 @@ olgm.gm.createStyleInternal = function(style, opt_index) {
 
 /**
  * Create a MapLabel object from a text style and Lat/Lng location.
- * @param {ol.style.Text} textStyle
- * @param {google.maps.LatLng} latLng
- * @param {number} index
- * @return {olgm.gm.MapLabel}
+ * @param {ol.style.Text} textStyle style for the text
+ * @param {google.maps.LatLng} latLng position of the label
+ * @param {number} index index for the label
+ * @return {olgm.gm.MapLabel} map label
  */
 olgm.gm.createLabel = function(textStyle, latLng, index) {
 

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -1,7 +1,6 @@
 goog.provide('olgm.gm.ImageOverlay');
 
 
-
 /**
  * Creates a new image overlay.
  * @constructor

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -34,7 +34,6 @@
 goog.provide('olgm.gm.MapLabel');
 
 
-
 /**
  * Creates a new Map Label
  * @constructor
@@ -79,7 +78,7 @@ olgm.gm.MapLabel.prototype.width_ = 0;
 
 /**
  * Note: mark as `@api` to make the minimized version include this method.
- * @param {string} prop
+ * @param {string} prop property
  * @api
  */
 olgm.gm.MapLabel.prototype.changed = function(prop) {
@@ -101,6 +100,8 @@ olgm.gm.MapLabel.prototype.changed = function(prop) {
     case 'offsetY':
     case 'position':
       this.draw();
+      break;
+    default:
       break;
   }
 };
@@ -201,7 +202,7 @@ olgm.gm.MapLabel.prototype.draw = function() {
 
 /**
  * Note: mark as `@api` to make the minimized version include this method.
- * @return {boolean}
+ * @return {boolean} whether or not the function ran successfully
  * @private
  */
 olgm.gm.MapLabel.prototype.redraw_ = function() {

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -6,7 +6,6 @@ goog.require('olgm.gm');
 goog.require('olgm.herald.Herald');
 
 
-
 /**
  * The Feature Herald is responsible of synchronizing a single ol3 vector
  * feature to a gmap feature. Here's what synchronized within the feature:
@@ -14,11 +13,11 @@ goog.require('olgm.herald.Herald');
  * - its geometry
  * - its style
  *
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
- * @param {ol.Feature} feature
- * @param {!google.maps.Data} data
- * @param {number} index
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
+ * @param {ol.Feature} feature feature to synchronise
+ * @param {!google.maps.Data} data google maps data
+ * @param {number} index feature index
  * @constructor
  * @extends {olgm.herald.Herald}
  */

--- a/src/herald/herald.js
+++ b/src/herald/herald.js
@@ -4,14 +4,13 @@ goog.require('olgm');
 goog.require('olgm.Abstract');
 
 
-
 /**
  * Abstract class for all heralds. When activated, an herald synchronizes
  * something from the OpenLayers map to the Google Maps one. When deactivated,
  * it stops doing so.
  *
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  * @extends {olgm.Abstract}
  */

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -4,11 +4,10 @@ goog.require('olgm.gm.ImageOverlay');
 goog.require('olgm.herald.Source');
 
 
-
 /**
  * Listen to a Image WMS layer
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  * @extends {olgm.herald.Source}
  */
@@ -31,7 +30,7 @@ goog.inherits(olgm.herald.ImageWMSSource, olgm.herald.Source);
 
 
 /**
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to watch
  * @override
  */
 olgm.herald.ImageWMSSource.prototype.watchLayer = function(layer) {
@@ -74,7 +73,7 @@ olgm.herald.ImageWMSSource.prototype.watchLayer = function(layer) {
 
 /**
  * Unwatch the WMS Image layer
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to unwatch
  * @override
  */
 olgm.herald.ImageWMSSource.prototype.unwatchLayer = function(layer) {
@@ -106,7 +105,8 @@ olgm.herald.ImageWMSSource.prototype.activate = function() {
 
 /**
  * Activates an image WMS layer cache item.
- * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem cacheItem to
+ * activate
  * @private
  */
 olgm.herald.ImageWMSSource.prototype.activateCacheItem_ = function(
@@ -133,7 +133,8 @@ olgm.herald.ImageWMSSource.prototype.deactivate = function() {
 
 /**
  * Deactivates an Image WMS layer cache item.
- * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem cacheItem to
+ * deactivate
  * @private
  */
 olgm.herald.ImageWMSSource.prototype.deactivateCacheItem_ = function(
@@ -148,8 +149,8 @@ olgm.herald.ImageWMSSource.prototype.deactivateCacheItem_ = function(
 
 /**
  * Generate a wms request url for a single image
- * @param {ol.layer.Image} layer
- * @return {string}
+ * @param {ol.layer.Image} layer layer to query
+ * @return {string} url to the requested tile
  * @private
  */
 olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
@@ -196,7 +197,8 @@ olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
 
 /**
  * Refresh the custom image overlay on google maps
- * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem cacheItem for the
+ * layer to update
  * @private
  */
 olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(cacheItem) {
@@ -254,7 +256,8 @@ olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(cacheItem) {
 
 /**
  * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
- * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem cacheItem for the
+ * watched layer
  * @private
  */
 olgm.herald.ImageWMSSource.prototype.handleVisibleChange_ = function(
@@ -272,7 +275,8 @@ olgm.herald.ImageWMSSource.prototype.handleVisibleChange_ = function(
 
 /**
  * Handle the map being panned when an ImageWMS layer is present
- * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem
+ * @param {olgm.herald.ImageWMSSource.LayerCache} cacheItem cacheItem for the
+ * watched layer
  * @private
  */
 olgm.herald.ImageWMSSource.prototype.handleMoveEnd_ = function(

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -10,7 +10,6 @@ goog.require('olgm.herald.View');
 goog.require('olgm.layer.Google');
 
 
-
 /**
  * The Layers Herald is responsible of synchronizing the layers from the
  * OpenLayers map to the Google Maps one. It listens to layers added and
@@ -41,9 +40,9 @@ goog.require('olgm.layer.Google');
  *     fully transparent, making the interactions still possible over it
  *     while being invisible.
  *
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
- * @param {boolean} watchVector
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
+ * @param {boolean} watchVector whether we should watch vector layers or not
  * @constructor
  * @extends {olgm.herald.Herald}
  */
@@ -184,7 +183,7 @@ olgm.herald.Layers.prototype.deactivate = function() {
 
 
 /**
- * @return {boolean}
+ * @return {boolean} whether google maps is active or not
  */
 olgm.herald.Layers.prototype.getGoogleMapsActive = function() {
   return this.googleMapsIsActive_;
@@ -193,7 +192,7 @@ olgm.herald.Layers.prototype.getGoogleMapsActive = function() {
 
 /**
  * Set the googleMapsIsActive value and spread the change to the heralds
- * @param {boolean} active
+ * @param {boolean} active value to update the google maps active flag with
  * @private
  */
 olgm.herald.Layers.prototype.setGoogleMapsActive_ = function(active) {
@@ -230,7 +229,7 @@ olgm.herald.Layers.prototype.handleLayersRemove_ = function(event) {
 
 /**
  * Watch the layer
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to watch
  * @private
  */
 olgm.herald.Layers.prototype.watchLayer_ = function(layer) {
@@ -251,7 +250,7 @@ olgm.herald.Layers.prototype.watchLayer_ = function(layer) {
 
 /**
  * Watch the google layer
- * @param {olgm.layer.Google} layer
+ * @param {olgm.layer.Google} layer google layer to watch
  * @private
  */
 olgm.herald.Layers.prototype.watchGoogleLayer_ = function(layer) {
@@ -268,7 +267,7 @@ olgm.herald.Layers.prototype.watchGoogleLayer_ = function(layer) {
 
 /**
  * Unwatch the layer
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to unwatch
  * @private
  */
 olgm.herald.Layers.prototype.unwatchLayer_ = function(layer) {
@@ -277,7 +276,6 @@ olgm.herald.Layers.prototype.unwatchLayer_ = function(layer) {
   } else if (layer instanceof ol.layer.Vector && this.watchVector_) {
     this.vectorSourceHerald_.unwatchLayer(layer);
   } else if (layer instanceof ol.layer.Tile) {
-    var source = layer.getSource();
     this.tileSourceHerald_.unwatchLayer(layer);
   } else if (layer instanceof ol.layer.Image) {
     var source = layer.getSource();
@@ -290,7 +288,7 @@ olgm.herald.Layers.prototype.unwatchLayer_ = function(layer) {
 
 /**
  * Unwatch the google layer
- * @param {olgm.layer.Google} layer
+ * @param {olgm.layer.Google} layer google layer to unwatch
  * @private
  */
 olgm.herald.Layers.prototype.unwatchGoogleLayer_ = function(layer) {

--- a/src/herald/sourceherald.js
+++ b/src/herald/sourceherald.js
@@ -3,13 +3,12 @@ goog.provide('olgm.herald.Source');
 goog.require('olgm.herald.Herald');
 
 
-
 /**
  * This is an abstract class. Children of this class will listen to one or
  * multiple layers of a specific class to render them using the Google Maps
  * API whenever a Google Maps layer is active.
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  * @extends {olgm.herald.Herald}
  */
@@ -48,7 +47,7 @@ olgm.herald.Source.prototype.unwatchLayer = goog.abstractMethod;
 
 /**
  * Set the googleMapsIsActive value to true or false
- * @param {boolean} active
+ * @param {boolean} active whether or not google maps is active
  * @api
  */
 olgm.herald.Source.prototype.setGoogleMapsActive = function(active) {

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -3,11 +3,10 @@ goog.provide('olgm.herald.TileSource');
 goog.require('olgm.herald.Source');
 
 
-
 /**
  * Listen to a tiled layer
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  * @extends {olgm.herald.Source}
  */
@@ -30,7 +29,7 @@ goog.inherits(olgm.herald.TileSource, olgm.herald.Source);
 
 
 /**
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to watch
  * @override
  */
 olgm.herald.TileSource.prototype.watchLayer = function(layer) {
@@ -83,10 +82,10 @@ olgm.herald.TileSource.prototype.watchLayer = function(layer) {
 /**
  * This function is used by google maps to get the url for a tile at the given
  * coordinates and zoom level
- * @param {ol.layer.Tile} tileLayer
- * @param {google.maps.Point} coords
- * @param {Number} zoom
- * @return {string|undefined}
+ * @param {ol.layer.Tile} tileLayer layer to query
+ * @param {google.maps.Point} coords coordinates of the tile
+ * @param {Number} zoom current zoom level
+ * @return {string|undefined} url to the tile
  * @private
  */
 olgm.herald.TileSource.prototype.googleGetTileUrlFunction_ = function(
@@ -144,7 +143,7 @@ olgm.herald.TileSource.prototype.googleGetTileUrlFunction_ = function(
 
 /**
  * Unwatch the tile layer
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to unwatch
  * @override
  */
 olgm.herald.TileSource.prototype.unwatchLayer = function(layer) {
@@ -188,7 +187,7 @@ olgm.herald.TileSource.prototype.activate = function() {
 
 /**
  * Activates an tile layer cache item.
- * @param {olgm.herald.TileSource.LayerCache} cacheItem
+ * @param {olgm.herald.TileSource.LayerCache} cacheItem cacheItem to activate
  * @private
  */
 olgm.herald.TileSource.prototype.activateCacheItem_ = function(
@@ -213,7 +212,7 @@ olgm.herald.TileSource.prototype.deactivate = function() {
 
 /**
  * Deactivates a Tile layer cache item.
- * @param {olgm.herald.TileSource.LayerCache} cacheItem
+ * @param {olgm.herald.TileSource.LayerCache} cacheItem cacheItem to deactivate
  * @private
  */
 olgm.herald.TileSource.prototype.deactivateCacheItem_ = function(
@@ -224,7 +223,8 @@ olgm.herald.TileSource.prototype.deactivateCacheItem_ = function(
 
 /**
  * Deal with the google tile layer when we enable or disable the OL3 tile layer
- * @param {olgm.herald.TileSource.LayerCache} cacheItem
+ * @param {olgm.herald.TileSource.LayerCache} cacheItem cacheItem for the
+ * watched layer
  * @private
  */
 olgm.herald.TileSource.prototype.handleVisibleChange_ = function(

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -5,17 +5,16 @@ goog.require('olgm.herald.Feature');
 goog.require('olgm.herald.Herald');
 
 
-
 /**
  * The VectorFeature Herald is responsible of sychronizing the features from
  * an ol3 vector source. The existing features in addition of those that are
  * added and removed are all managed. Each existing or added feature is bound
  * to a `olgm.herald.Feature` object. It gets unbound when removed.
  *
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
- * @param {!ol.source.Vector} source
- * @param {!google.maps.Data} data
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
+ * @param {!ol.source.Vector} source vector source
+ * @param {!google.maps.Data} data google maps data object
  * @constructor
  * @extends {olgm.herald.Herald}
  */
@@ -78,7 +77,7 @@ olgm.herald.VectorFeature.prototype.deactivate = function() {
 
 
 /**
- * @param {ol.source.VectorEvent} event
+ * @param {ol.source.VectorEvent} event addFeature event
  * @private
  */
 olgm.herald.VectorFeature.prototype.handleAddFeature_ = function(event) {
@@ -89,7 +88,7 @@ olgm.herald.VectorFeature.prototype.handleAddFeature_ = function(event) {
 
 
 /**
- * @param {ol.source.VectorEvent} event
+ * @param {ol.source.VectorEvent} event removeFeature event
  * @private
  */
 olgm.herald.VectorFeature.prototype.handleRemoveFeature_ = function(event) {
@@ -100,7 +99,7 @@ olgm.herald.VectorFeature.prototype.handleRemoveFeature_ = function(event) {
 
 
 /**
- * @param {ol.Feature} feature
+ * @param {ol.Feature} feature feature to watch
  * @private
  */
 olgm.herald.VectorFeature.prototype.watchFeature_ = function(feature) {
@@ -127,7 +126,7 @@ olgm.herald.VectorFeature.prototype.watchFeature_ = function(feature) {
 
 
 /**
- * @param {ol.Feature} feature
+ * @param {ol.Feature} feature feature to unwatch
  * @private
  */
 olgm.herald.VectorFeature.prototype.unwatchFeature_ = function(feature) {

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -4,11 +4,10 @@ goog.require('olgm.herald.Source');
 goog.require('olgm.herald.VectorFeature');
 
 
-
 /**
  * Listen to a Vector layer
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  * @extends {olgm.herald.Source}
  */
@@ -31,7 +30,7 @@ goog.inherits(olgm.herald.VectorSource, olgm.herald.Source);
 
 
 /**
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to watch
  * @override
  */
 olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
@@ -83,7 +82,7 @@ olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
 
 /**
  * Unwatch the WMS tile layer
- * @param {ol.layer.Base} layer
+ * @param {ol.layer.Base} layer layer to unwatch
  * @override
  */
 olgm.herald.VectorSource.prototype.unwatchLayer = function(layer) {
@@ -124,7 +123,7 @@ olgm.herald.VectorSource.prototype.activate = function() {
 
 /**
  * Activates an image WMS layer cache item.
- * @param {olgm.herald.VectorSource.LayerCache} cacheItem
+ * @param {olgm.herald.VectorSource.LayerCache} cacheItem cacheItem to activate
  * @private
  */
 olgm.herald.VectorSource.prototype.activateCacheItem_ = function(
@@ -150,7 +149,8 @@ olgm.herald.VectorSource.prototype.deactivate = function() {
 
 /**
  * Deactivates a Tile WMS layer cache item.
- * @param {olgm.herald.VectorSource.LayerCache} cacheItem
+ * @param {olgm.herald.VectorSource.LayerCache} cacheItem cacheItem to
+ * deactivate
  * @private
  */
 olgm.herald.VectorSource.prototype.deactivateCacheItem_ = function(
@@ -162,7 +162,8 @@ olgm.herald.VectorSource.prototype.deactivateCacheItem_ = function(
 
 /**
  * Deal with the google WMS layer when we enable or disable the OL3 WMS layer
- * @param {olgm.herald.VectorSource.LayerCache} cacheItem
+ * @param {olgm.herald.VectorSource.LayerCache} cacheItem cacheItem for the
+ * watched layer
  * @private
  */
 olgm.herald.VectorSource.prototype.handleVisibleChange_ = function(

--- a/src/herald/viewherald.js
+++ b/src/herald/viewherald.js
@@ -7,7 +7,6 @@ goog.require('olgm');
 goog.require('olgm.herald.Herald');
 
 
-
 /**
  * The View Herald is responsible of synchronizing the view (center/zoom)
  * of boths maps together. The ol3 map view is the master here, i.e. changes
@@ -15,8 +14,8 @@ goog.require('olgm.herald.Herald');
  *
  * When the browser window gets resized, the gmap map is also updated.
  *
- * @param {!ol.Map} ol3map
- * @param {!google.maps.Map} gmap
+ * @param {!ol.Map} ol3map openlayers map
+ * @param {!google.maps.Map} gmap google maps map
  * @constructor
  * @extends {olgm.herald.Herald}
  */

--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -3,7 +3,6 @@ goog.provide('olgm.layer.Google');
 goog.require('ol.layer.Group');
 
 
-
 /**
  * An ol3 layer object serving the purpose of being added to the ol3 map
  * as dummy layer. The `mapTypeId` defines which Google Maps map type the
@@ -38,7 +37,7 @@ goog.inherits(olgm.layer.Google, ol.layer.Group);
 
 
 /**
- * @return {google.maps.MapTypeId.<(number|string)>|string}
+ * @return {google.maps.MapTypeId.<(number|string)>|string} map type id
  * @api
  */
 olgm.layer.Google.prototype.getMapTypeId = function() {
@@ -47,7 +46,7 @@ olgm.layer.Google.prototype.getMapTypeId = function() {
 
 
 /**
- * @return {?Array.<google.maps.MapTypeStyle>}
+ * @return {?Array.<google.maps.MapTypeStyle>} map styles
  */
 olgm.layer.Google.prototype.getStyles = function() {
   return this.styles_;

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -4,7 +4,6 @@ goog.require('olgm.Abstract');
 goog.require('olgm.herald.Layers');
 
 
-
 /**
  * The main component of this library. It binds an existing OpenLayers map to
  * a Google Maps map it creates through the use of `herald` objects. Each
@@ -120,7 +119,7 @@ olgm.OLGoogleMaps.prototype.deactivate = function() {
 
 
 /**
- * @return {boolean}
+ * @return {boolean} whether or not google maps is active
  * @api
  */
 olgm.OLGoogleMaps.prototype.getGoogleMapsActive = function() {
@@ -129,7 +128,7 @@ olgm.OLGoogleMaps.prototype.getGoogleMapsActive = function() {
 
 
 /**
- * @return {google.maps.Map}
+ * @return {google.maps.Map} the google maps map
  * @api
  */
 olgm.OLGoogleMaps.prototype.getGoogleMapsMap = function() {

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -32,8 +32,8 @@ olgm.RESOLUTIONS = [
 
 
 /**
- * @param {ol.geom.Geometry} geometry
- * @return {ol.Coordinate}
+ * @param {ol.geom.Geometry} geometry the geometry to get the center of
+ * @return {ol.Coordinate} the center coordinates
  */
 olgm.getCenterOf = function(geometry) {
 
@@ -52,8 +52,9 @@ olgm.getCenterOf = function(geometry) {
 
 
 /**
- * @param {string|Array.<number>|CanvasGradient|CanvasPattern} color
- * @return {string}
+ * @param {string|Array.<number>|CanvasGradient|CanvasPattern} color the color
+ * to parse
+ * @return {string} the parsed color
  */
 olgm.getColor = function(color) {
 
@@ -82,8 +83,9 @@ olgm.getColor = function(color) {
 
 
 /**
- * @param {string|Array.<number>|CanvasGradient|CanvasPattern} color
- * @return {?number}
+ * @param {string|Array.<number>|CanvasGradient|CanvasPattern} color the color
+ * to check
+ * @return {?number} the color's opacity
  */
 olgm.getColorOpacity = function(color) {
 
@@ -111,9 +113,9 @@ olgm.getColorOpacity = function(color) {
 
 /**
  * Get the style from the specified object.
- * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature} object
-
- * @return {?ol.style.Style}
+ * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature}
+ object object from which we get the style
+ * @return {?ol.style.Style} the style of the object
  */
 olgm.getStyleOf = function(object) {
 
@@ -136,8 +138,8 @@ olgm.getStyleOf = function(object) {
 
 
 /**
- * @param {number} resolution
- * @return {?number}
+ * @param {number} resolution the resolution to get the zoom from
+ * @return {?number} the zoom from the resolution, if found
  */
 olgm.getZoomFromResolution = function(resolution) {
 
@@ -159,8 +161,8 @@ olgm.getZoomFromResolution = function(resolution) {
 /**
  * Source: http://stackoverflow.com/questions/7543818/\
  *     regex-javascript-to-match-both-rgb-and-rgba
- * @param {string} rgbaString
- * @return {?Array.<number>}
+ * @param {string} rgbaString the rgbaString to parse
+ * @return {?Array.<number>} the rgba color in number array format
  */
 olgm.parseRGBA = function(rgbaString) {
   var rgba = null;
@@ -179,9 +181,9 @@ olgm.parseRGBA = function(rgbaString) {
 
 
 /**
- * @param {string} string
- * @param {string} needle
- * @return {boolean}
+ * @param {string} string string to check
+ * @param {string} needle string to find
+ * @return {boolean} whether or not the needle was found in the string
  */
 olgm.stringStartsWith = function(string, needle) {
   return (string.indexOf(needle) === 0);
@@ -189,8 +191,9 @@ olgm.stringStartsWith = function(string, needle) {
 
 
 /**
- * @param {Array.<ol.events.Key|Array.<ol.events.Key>>} listenerKeys
- * @param {Array.<goog.events.Key>=} opt_googListenerKeys
+ * @param {Array.<ol.events.Key|Array.<ol.events.Key>>} listenerKeys listener
+ * keys
+ * @param {Array.<goog.events.Key>=} opt_googListenerKeys closure listener keys
  */
 olgm.unlistenAllByKey = function(listenerKeys, opt_googListenerKeys) {
   listenerKeys.forEach(ol.Observable.unByKey);


### PR DESCRIPTION
This commit switches the linter to eslint. The reason for this is that this library is an add-on to openlayers, and openlayers switched to this linter. It is important that this library follows the same code standards than the one it extends.
