### PR TITLE
Render markers using canvas on Google Maps

### DIFF
--- a/examples/concept.js
+++ b/examples/concept.js
@@ -197,32 +197,42 @@ var addPointFeatures = function(len, opt_style) {
   for (var i = 0; i < len; i++) {
     feature = generatePointFeature();
     if (opt_style) {
-      feature.setStyle(opt_style);
+      var style = new ol.style.Style(opt_style);
+      style.setZIndex(Math.floor(Math.random() * 1000));
+      feature.setStyle(style);
     }
     vector.getSource().addFeature(feature);
   }
 };
 
 var addMarkerFeatures = function(len) {
-  addPointFeatures(len, new ol.style.Style({
+  addPointFeatures(len, {
     image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
       anchor: [0.5, 46],
       anchorXUnits: 'fraction',
       anchorYUnits: 'pixels',
       opacity: 0.75,
       src: 'data/icon.png'
-    }))
-  }));
+    })),
+    text: new ol.style.Text({
+      offsetX: 0,
+      offsetY: -32,
+      font: 'normal 14pt Courrier',
+      text: 'hi',
+      fill: new ol.style.Fill({color: 'black'}),
+      stroke: new ol.style.Stroke({color: '#ffffff', width: 5}),
+    })
+  });
 };
 
 var addCircleFeatures = function(len) {
-  addPointFeatures(len, new ol.style.Style({
+  addPointFeatures(len, {
     image: new ol.style.Circle({
       'fill': new ol.style.Fill({color: 'rgba(153,51,51,0.3)'}),
       'stroke': new ol.style.Stroke({color: 'rgb(153,51,51)', width: 2}),
       'radius': 20
     })
-  }));
+  });
 };
 
 var addLineFeatures = function(len, opt_style) {
@@ -238,7 +248,7 @@ var addLineFeatures = function(len, opt_style) {
 
 
 addPointFeatures(3);
-addPointFeatures(3, new ol.style.Style({
+addPointFeatures(3, {
   image: new ol.style.Circle({
     'fill': new ol.style.Fill({color: '#3F5D7D'}),
     'stroke': new ol.style.Stroke({color: 'rgb(30,30,30)', width: 2}),
@@ -250,7 +260,7 @@ addPointFeatures(3, new ol.style.Style({
     fill: new ol.style.Fill({color: 'black'}),
     stroke: new ol.style.Stroke({color: 'white', width: 3})
   })
-}));
+});
 addMarkerFeatures(3);
 addCircleFeatures(3);
 addLineFeatures(1);
@@ -281,7 +291,11 @@ poly2.setStyle(new ol.style.Style({
 vector.getSource().addFeature(poly2);
 
 
-var olGM = new olgm.OLGoogleMaps({map: map});
+var olGM = new olgm.OLGoogleMaps({
+  map: map,
+  mapIconOptions: {
+    useCanvas: true
+  }});
 olGM.activate();
 
 document.getElementById('toggle').onclick = function() {

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -16,7 +16,9 @@ feature.setStyle(new ol.style.Style({
       anchorYUnits: 'pixels',
       size: [32, 48],
       scale: 0.75,
-      src: 'data/icon.png'
+      src: 'data/icon.png',
+      rotation: 0.25 * Math.PI,
+      opacity: 0.5
     }))
   }));
 source.addFeature(feature);

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -41,7 +41,11 @@ var map = new ol.Map({
   })
 });
 
-var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+var olGM = new olgm.OLGoogleMaps({
+  map: map,
+  mapIconOptions: {
+    useCanvas: true
+  }}); // map is the ol.Map instance
 olGM.activate();
 
 

--- a/examples/label.html
+++ b/examples/label.html
@@ -28,7 +28,8 @@
           <p>
             The MapLabel library, which is natively included in
             OL3-Google-Maps, takes care of rendering the text labels in
-            Google Maps.
+            Google Maps. It has been extended to support displaying markers
+            over labels.
           </p>
 
           <input id="toggle" type="button" onclick="toggle();"

--- a/examples/label.js
+++ b/examples/label.js
@@ -87,7 +87,7 @@ for (var i = 0; i < 10; i++) {
         anchor: [0.5, 46],
         anchorXUnits: 'fraction',
         anchorYUnits: 'pixels',
-        src: 'data/icon.png',
+        src: 'data/icon.png'
       })),
       text: new ol.style.Text({
         offsetX: 0,
@@ -124,7 +124,10 @@ var map = new ol.Map({
   })
 });
 
-var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+var olGM = new olgm.OLGoogleMaps({
+  map: map,
+  useCanvas: true
+}); // map is the ol.Map instance
 olGM.activate();
 
 

--- a/examples/label.js
+++ b/examples/label.js
@@ -72,6 +72,39 @@ marker.setStyle(new ol.style.Style({
   }));
 
 source.addFeatures([feature, feature2, feature3, marker]);
+
+// Add some randomly generated markers
+
+var markers = [];
+var letters = "abcdefghijklmnopqrstuvwxyz"
+
+for (var i = 0; i < 10; i++) {
+  var x = Math.floor((Math.random() * 10000) - 7912700);
+  var y =  Math.floor((Math.random() * 10000) + 6171500);
+  var marker = new ol.Feature(new ol.geom.Point([x, y]));
+  marker.setStyle(new ol.style.Style({
+      image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+        anchor: [0.5, 46],
+        anchorXUnits: 'fraction',
+        anchorYUnits: 'pixels',
+        src: 'data/icon.png',
+      })),
+      text: new ol.style.Text({
+        offsetX: 0,
+        offsetY: -32,
+        font: 'normal 14pt Courrier',
+        text: letters.charAt(i) + letters.charAt(i+1),
+        fill: new ol.style.Fill({color: 'black'}),
+        stroke: new ol.style.Stroke({color: '#aaffaa', width: 6}),
+      }),
+      zIndex: i
+    })
+  );
+  markers.push(marker);
+}
+
+source.addFeatures(markers);
+
 var vector = new ol.layer.Vector({
   source: source
 });

--- a/examples/label.js
+++ b/examples/label.js
@@ -126,7 +126,9 @@ var map = new ol.Map({
 
 var olGM = new olgm.OLGoogleMaps({
   map: map,
-  useCanvas: true
+  mapIconOptions: {
+    useCanvas: true
+  }
 }); // map is the ol.Map instance
 olGM.activate();
 

--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -50,7 +50,7 @@ olgmx.gm = {};
 
 /**
  * @typedef {{
- *   useCanvas: (boolean)
+ *   useCanvas: (boolean|undefined)
  * }}
  * @api
  */
@@ -60,7 +60,7 @@ olgmx.gm.MapIconOptions;
 /**
  * Whether or not we should draw on canvases when we can, instead of using the
  * Google Maps API. This fixes z-index issues with labels on markers
- * @type {boolean}
+ * @type {boolean|undefined}
  * @api
  */
 olgmx.gm.MapIconOptions.prototype.useCanvas;

--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -9,6 +9,7 @@ var olgmx;
 /**
  * @typedef {{
  *   map: (!ol.Map),
+ *   useCanvas: (boolean|undefined),
  *   watchVector: (boolean|undefined)
  * }}
  * @api
@@ -25,12 +26,39 @@ olgmx.OLGoogleMapsOptions.prototype.map;
 
 
 /**
+ * Whether or not we should draw on canvases when we can, instead of using the
+ * Google Maps API. This fixes z-index issues with labels on markers
+ * @type {boolean|undefined}
+ * @api
+ */
+olgmx.OLGoogleMapsOptions.prototype.useCanvas;
+
+
+/**
  * Whether the library should watch vector layers and let them be rendered
  * by Google Maps with the latter is activated or not.  Defaults to `true`.
  * @type {boolean|undefined}
  * @api
  */
 olgmx.OLGoogleMapsOptions.prototype.watchVector;
+
+
+/**
+ * @type {Object}
+ */
+olgmx.herald = {};
+
+
+/**
+ * @typedef {{
+ *   feature: (ol.Feature),
+ *   data: (!google.maps.Data),
+ *   index: (number),
+ *   useCanvas: (boolean)
+ * }}
+ * @api
+ */
+olgmx.herald.FeatureOptions;
 
 
 /**

--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -26,6 +26,14 @@ olgmx.OLGoogleMapsOptions.prototype.map;
 
 
 /**
+ * Options for the MapIcon object if it exists
+ * @type {olgmx.gm.MapIconOptions|undefined}
+ * @api
+ */
+olgmx.OLGoogleMapsOptions.prototype.mapIconOptions;
+
+
+/**
  * Whether the library should watch vector layers and let them be rendered
  * by Google Maps with the latter is activated or not.  Defaults to `true`.
  * @type {boolean|undefined}
@@ -52,7 +60,7 @@ olgmx.gm.MapIconOptions;
 /**
  * Whether or not we should draw on canvases when we can, instead of using the
  * Google Maps API. This fixes z-index issues with labels on markers
- * @type {boolean|undefined}
+ * @type {boolean}
  * @api
  */
 olgmx.gm.MapIconOptions.prototype.useCanvas;

--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -9,7 +9,7 @@ var olgmx;
 /**
  * @typedef {{
  *   map: (!ol.Map),
- *   useCanvas: (boolean|undefined),
+ *   mapIconOptions: (olgmx.gm.MapIconOptions|undefined),
  *   watchVector: (boolean|undefined)
  * }}
  * @api
@@ -26,21 +26,36 @@ olgmx.OLGoogleMapsOptions.prototype.map;
 
 
 /**
- * Whether or not we should draw on canvases when we can, instead of using the
- * Google Maps API. This fixes z-index issues with labels on markers
- * @type {boolean|undefined}
- * @api
- */
-olgmx.OLGoogleMapsOptions.prototype.useCanvas;
-
-
-/**
  * Whether the library should watch vector layers and let them be rendered
  * by Google Maps with the latter is activated or not.  Defaults to `true`.
  * @type {boolean|undefined}
  * @api
  */
 olgmx.OLGoogleMapsOptions.prototype.watchVector;
+
+
+/**
+ * @type {Object}
+ */
+olgmx.gm = {};
+
+
+/**
+ * @typedef {{
+ *   useCanvas: (boolean)
+ * }}
+ * @api
+ */
+olgmx.gm.MapIconOptions;
+
+
+/**
+ * Whether or not we should draw on canvases when we can, instead of using the
+ * Google Maps API. This fixes z-index issues with labels on markers
+ * @type {boolean|undefined}
+ * @api
+ */
+olgmx.gm.MapIconOptions.prototype.useCanvas;
 
 
 /**
@@ -54,7 +69,7 @@ olgmx.herald = {};
  *   feature: (ol.Feature),
  *   data: (!google.maps.Data),
  *   index: (number),
- *   useCanvas: (boolean)
+ *   mapIconOptions: (olgmx.gm.MapIconOptions)
  * }}
  * @api
  */

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -176,6 +176,7 @@ olgm.gm.createStyleInternal = function(style, opt_index) {
 
   var image = style.getImage();
   if (image) {
+
     var gmIcon = {};
     var gmSymbol = {};
 
@@ -214,44 +215,6 @@ olgm.gm.createStyleInternal = function(style, opt_index) {
       if (imageRadius) {
         gmSymbol['scale'] = imageRadius;
       }
-    } else if (image instanceof ol.style.Icon) {
-      // --- ol.style.Icon ---
-
-      var imageSrc = image.getSrc();
-      if (imageSrc) {
-        gmSymbol['url'] = imageSrc;
-      }
-
-      var imageScale = image.getScale();
-
-      var imageAnchor = image.getAnchor();
-      if (imageAnchor) {
-        if (imageScale !== undefined) {
-          gmSymbol['anchor'] = new google.maps.Point(
-              imageAnchor[0] * imageScale, imageAnchor[1] * imageScale);
-        } else {
-          gmSymbol['anchor'] = new google.maps.Point(
-              imageAnchor[0], imageAnchor[1]);
-        }
-      }
-
-      var imageOrigin = image.getOrigin();
-      if (imageOrigin) {
-        gmSymbol['origin'] = new google.maps.Point(
-            imageOrigin[0], imageOrigin[1]);
-      }
-
-      var imageSize = image.getSize();
-      if (imageSize) {
-        gmSymbol['size'] = new google.maps.Size(imageSize[0], imageSize[1]);
-
-        if (imageScale !== undefined) {
-          gmSymbol['scaledSize'] = new google.maps.Size(
-              imageSize[0] * imageScale, imageSize[1] * imageScale);
-        }
-      }
-
-      // NOTE - google.maps.Icon does not support opacity
     }
 
     if (Object.keys(gmIcon).length) {
@@ -345,4 +308,15 @@ olgm.gm.createLabel = function(textStyle, latLng, index) {
   }
 
   return new olgm.gm.MapLabel(labelOptions);
+};
+
+olgm.gm.createMarker = function(imageStyle, latLng, index) {
+
+  var markerOptions = {
+    align: 'center',
+    position: latLng,
+    zIndex: index * 2 + 1
+  };
+
+  return new olgm.gm.MapMarker(imageStyle, markerOptions);
 };

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -3,6 +3,7 @@ goog.provide('olgm.gm');
 goog.require('goog.asserts');
 goog.require('olgm');
 goog.require('olgm.gm.MapLabel');
+goog.require('olgm.gm.MapIcon');
 
 
 // === Data ===
@@ -318,5 +319,5 @@ olgm.gm.createMarker = function(imageStyle, latLng, index) {
     zIndex: index * 2 + 1
   };
 
-  return new olgm.gm.MapMarker(imageStyle, markerOptions);
+  return new olgm.gm.MapIcon(imageStyle, markerOptions);
 };

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -118,17 +118,15 @@ olgm.gm.createGeometry = function(geometry, opt_ol3map) {
  * Create a Google Maps data style options from an OpenLayers object.
  * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature}
  * object style object
- * @param {boolean} useCanvas whether or not we should draw on canvases when
- * we can, instead of using the Google Maps API. This fixes z-index issues
- * with labels on markers
+ * @param {olgmx.gm.MapIconOptions} mapIconOptions map icon options
  * @param {number=} opt_index index for the object
  * @return {?google.maps.Data.StyleOptions} google style options
  */
-olgm.gm.createStyle = function(object, useCanvas, opt_index) {
+olgm.gm.createStyle = function(object, mapIconOptions, opt_index) {
   var gmStyle = null;
   var style = olgm.getStyleOf(object);
   if (style) {
-    gmStyle = olgm.gm.createStyleInternal(style, useCanvas, opt_index);
+    gmStyle = olgm.gm.createStyleInternal(style, mapIconOptions, opt_index);
   }
   return gmStyle;
 };
@@ -137,13 +135,11 @@ olgm.gm.createStyle = function(object, useCanvas, opt_index) {
 /**
  * Create a Google Maps data style options from an OpenLayers style object.
  * @param {ol.style.Style} style style object
- * @param {boolean} useCanvas whether or not we should draw on canvases when
- * we can, instead of using the Google Maps API. This fixes z-index issues
- * with labels on markers
+ * @param {olgmx.gm.MapIconOptions} mapIconOptions map icon options
  * @param {number=} opt_index index for the object
  * @return {google.maps.Data.StyleOptions} google style options
  */
-olgm.gm.createStyleInternal = function(style, useCanvas, opt_index) {
+olgm.gm.createStyleInternal = function(style, mapIconOptions, opt_index) {
 
   var gmStyle = /** @type {google.maps.Data.StyleOptions} */ ({});
 
@@ -186,6 +182,7 @@ olgm.gm.createStyleInternal = function(style, useCanvas, opt_index) {
 
     var gmIcon = {};
     var gmSymbol = {};
+    var useCanvas = mapIconOptions.useCanvas;
 
     if (image instanceof ol.style.Circle) {
       // --- ol.style.Circle ---

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -182,7 +182,8 @@ olgm.gm.createStyleInternal = function(style, mapIconOptions, opt_index) {
 
     var gmIcon = {};
     var gmSymbol = {};
-    var useCanvas = mapIconOptions.useCanvas;
+    var useCanvas = mapIconOptions.useCanvas !== undefined ?
+        mapIconOptions.useCanvas : false;
 
     if (image instanceof ol.style.Circle) {
       // --- ol.style.Circle ---

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -352,13 +352,21 @@ olgm.gm.createLabel = function(textStyle, latLng, index) {
   return new olgm.gm.MapLabel(labelOptions);
 };
 
-olgm.gm.createMarker = function(imageStyle, latLng, index) {
 
-  var markerOptions = {
+/**
+ * Create a mapIcon object from an image style and Lat/Lng location
+ * @param {ol.style.Icon} iconStyle style for the icon
+ * @param {google.maps.LatLng} latLng position of the label
+ * @param {number} index index for the label
+ * @return {olgm.gm.MapIcon} map label
+ */
+olgm.gm.createMapIcon = function(iconStyle, latLng, index) {
+
+  var iconOptions = {
     align: 'center',
     position: latLng,
     zIndex: index * 2 + 1
   };
 
-  return new olgm.gm.MapIcon(imageStyle, markerOptions);
+  return new olgm.gm.MapIcon(iconStyle, iconOptions);
 };

--- a/src/gm/mapelement.js
+++ b/src/gm/mapelement.js
@@ -1,0 +1,149 @@
+goog.provide('olgm.gm.MapElement');
+
+/**
+ * This class is a parent for all elements that are drawn manually onto Google
+ * Maps. This means drawing elements on a canvas attached to the Google Maps
+ * map instead of drawing features on map tiles using their API.
+ * This needs to be done for elements that are supported in OpenLayers 3 but
+ * not in Google Maps, such as text labels on markers.
+ *
+ * Some of this code was borrowed from the MapLabel project, whose source code
+ * can be found here: https://github.com/googlemaps/js-map-label
+ */
+
+/**
+ * Creates a new Map Element, to be drawn as an OverlayView
+ * @constructor
+ * @extends {google.maps.OverlayView}
+ * @api
+ */
+olgm.gm.MapElement = function() {
+
+};
+if (window.google && window.google.maps) {
+  goog.inherits(olgm.gm.MapElement, google.maps.OverlayView);
+}
+
+
+/**
+ * @type {boolean}
+ * @private
+ */
+olgm.gm.MapElement.prototype.drawn_ = false;
+
+
+/**
+ * @type {number}
+ * @private
+ */
+olgm.gm.MapElement.prototype.height_ = 0;
+
+
+/**
+ * @type {number}
+ * @private
+ */
+olgm.gm.MapElement.prototype.width_ = 0;
+
+
+/**
+ * Draw features to the map (call redraw) and setup canvas if it's the first
+ * time we draw
+ * @api
+ */
+olgm.gm.MapElement.prototype.draw = function() {
+  if (this.drawn_) {
+    this.redraw_();
+    return;
+  }
+
+  var canvas = this.canvas_;
+  if (!canvas) {
+    // onAdd has not been called yet.
+    return;
+  }
+
+  var ctx = canvas.getContext('2d');
+  var height = ctx.canvas.height;
+  var width = ctx.canvas.width;
+  this.width_ = width;
+  this.height_ = height;
+
+  if (!this.redraw_()) {
+    return;
+  }
+
+  this.drawn_ = true;
+};
+
+
+/**
+ * Redraw features to the map
+ * @return {boolean} whether or not the function ran successfully
+ * @private
+ */
+olgm.gm.MapElement.prototype.redraw_ = function() {
+  var latLng = /** @type {google.maps.LatLng} */ (this.get('position'));
+  if (!latLng) {
+    return false;
+  }
+
+  var projection = this.getProjection();
+  if (!projection) {
+    // The map projection is not ready yet so do nothing
+    return false;
+  }
+
+  var pos = projection.fromLatLngToDivPixel(latLng);
+  var height = this.height_;
+  var width = this.width_;
+
+  var offsetX = this.get('offsetX') || 0;
+  var offsetY = this.get('offsetY') || 0;
+
+  var style = this.canvas_.style;
+  style['top'] = (pos.y - (height / 2) + offsetY) + 'px';
+  style['left'] = (pos.x - (width / 2) + offsetX) + 'px';
+
+  style['visibility'] = this.getVisible_();
+
+  return true;
+};
+
+
+/**
+ * Get the visibility of the element.
+ * @private
+ * @return {string} blank string if visible, 'hidden' if invisible.
+ */
+olgm.gm.MapElement.prototype.getVisible_ = function() {
+  var minZoom = /** @type {number} */ (this.get('minZoom'));
+  var maxZoom = /** @type {number} */ (this.get('maxZoom'));
+
+  if (minZoom === undefined && maxZoom === undefined) {
+    return '';
+  }
+
+  var map = this.getMap();
+  if (!map) {
+    return '';
+  }
+
+  var mapZoom = map.getZoom();
+  if (mapZoom < minZoom || mapZoom > maxZoom) {
+    return 'hidden';
+  }
+  return '';
+};
+
+
+/**
+ * Delete canvas when removing the element
+ * @api
+ */
+olgm.gm.MapElement.prototype.onRemove = function() {
+  var canvas = this.canvas_;
+  if (canvas && canvas.parentNode) {
+    canvas.parentNode.removeChild(canvas);
+  }
+};

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -23,12 +23,6 @@ olgm.gm.MapIcon = function(imageStyle, opt_options) {
    */
   this.imageStyle_ = imageStyle;
 
-  /**
-   * @type {Number}
-   * @private
-   */
-  this.scale_ = this.imageStyle_.getScale() || 1;
-
   this.setValues(opt_options);
 };
 goog.inherits(olgm.gm.MapIcon, olgm.gm.MapElement);
@@ -77,15 +71,21 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
   ctx.clearRect(0,0,canvas.width, canvas.height);
 
   var anchor = this.imageStyle_.getAnchor();
+  var scale = this.imageStyle_.getScale() || 1;
+  var rotation = this.imageStyle_.getRotation() || 0;
 
-  var offsetX = anchor[0] * this.scale_;
-  var offsetY = anchor[1] * this.scale_;
+  var offsetX = anchor[0] * scale;
+  var offsetY = anchor[1] * scale;
 
   var x = canvas.width / 2 - offsetX;
   var y = canvas.height / 2 - offsetY;
 
+  ctx.translate(x + offsetX, y + offsetY);
+  ctx.rotate(rotation);
+  ctx.translate(-x - offsetX, -y - offsetY);
+
   ctx.drawImage(image, x, y,
-    image.width * this.scale_, image.height * this.scale_);
+    image.width * scale, image.height * scale);
 };
 
 

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -23,6 +23,12 @@ olgm.gm.MapIcon = function(imageStyle, opt_options) {
    */
   this.imageStyle_ = imageStyle;
 
+  /**
+   * @type {Number}
+   * @private
+   */
+  this.scale_ = this.imageStyle_.getScale() || 1;
+
   this.setValues(opt_options);
 };
 goog.inherits(olgm.gm.MapIcon, olgm.gm.MapElement);
@@ -72,12 +78,14 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
 
   var anchor = this.imageStyle_.getAnchor();
 
-  var offsetX = anchor[0];
-  var offsetY = anchor[1];
+  var offsetX = anchor[0] * this.scale_;
+  var offsetY = anchor[1] * this.scale_;
 
   var x = canvas.width / 2 - offsetX;
   var y = canvas.height / 2 - offsetY;
-  ctx.drawImage(image, x, y);
+
+  ctx.drawImage(image, x, y,
+    image.width * this.scale_, image.height * this.scale_);
 };
 
 
@@ -94,6 +102,6 @@ olgm.gm.MapIcon.prototype.onAdd = function() {
 
   var panes = this.getPanes();
   if (panes) {
-    panes.iconLayer.appendChild(canvas);
+    panes.markerLayer.appendChild(canvas);
   }
 };

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -1,21 +1,21 @@
-goog.provide('olgm.gm.MapMarker');
+goog.provide('olgm.gm.MapIcon');
 
 goog.require('olgm.gm.MapElement');
 
 
 /**
- * Creates a new Map Marker
+ * Creates a new map icon
  * @constructor
  * @extends {olgm.gm.MapElement}
  * @param {olx.style.IconOptions} imageStyle ol3 style properties
  * @param {Object.<string, *>=} opt_options Optional properties to set.
  * @api
  */
-olgm.gm.MapMarker = function(imageStyle, opt_options) {
+olgm.gm.MapIcon = function(imageStyle, opt_options) {
   goog.base(this);
 
   /**
-   * This object contains the ol3 style properties for the marker. We keep
+   * This object contains the ol3 style properties for the icon. We keep
    * it as an object because its properties can change, for example the size
    * is only defined after the image is done loading.
    * @type {olx.style.IconOptions}
@@ -25,7 +25,7 @@ olgm.gm.MapMarker = function(imageStyle, opt_options) {
 
   this.setValues(opt_options);
 };
-goog.inherits(olgm.gm.MapMarker, olgm.gm.MapElement);
+goog.inherits(olgm.gm.MapIcon, olgm.gm.MapElement);
 
 
 /**
@@ -33,7 +33,7 @@ goog.inherits(olgm.gm.MapMarker, olgm.gm.MapElement);
  * @param {string} prop property
  * @api
  */
-olgm.gm.MapMarker.prototype.changed = function(prop) {
+olgm.gm.MapIcon.prototype.changed = function(prop) {
   switch (prop) {
     case 'maxZoom':
     case 'minZoom':
@@ -49,10 +49,10 @@ olgm.gm.MapMarker.prototype.changed = function(prop) {
 
 
 /**
- * Draws the marker to the canvas 2d context.
+ * Draws the icon to the canvas 2d context.
  * @private
  */
-olgm.gm.MapMarker.prototype.drawCanvas_ = function() {
+olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
   var canvas = this.canvas_;
   if (!canvas) {
     return;
@@ -85,7 +85,7 @@ olgm.gm.MapMarker.prototype.drawCanvas_ = function() {
  * Manage feature being added to the map
  * @api
  */
-olgm.gm.MapMarker.prototype.onAdd = function() {
+olgm.gm.MapIcon.prototype.onAdd = function() {
   var canvas = this.canvas_ = document.createElement('canvas');
   var style = canvas.style;
   style.position = 'absolute';
@@ -94,6 +94,6 @@ olgm.gm.MapMarker.prototype.onAdd = function() {
 
   var panes = this.getPanes();
   if (panes) {
-    panes.markerLayer.appendChild(canvas);
+    panes.iconLayer.appendChild(canvas);
   }
 };

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -7,7 +7,7 @@ goog.require('olgm.gm.MapElement');
  * Creates a new map icon
  * @constructor
  * @extends {olgm.gm.MapElement}
- * @param {olx.style.IconOptions} imageStyle ol3 style properties
+ * @param {ol.style.Icon} imageStyle ol3 style properties
  * @param {Object.<string, *>=} opt_options Optional properties to set.
  * @api
  */
@@ -18,7 +18,7 @@ olgm.gm.MapIcon = function(imageStyle, opt_options) {
    * This object contains the ol3 style properties for the icon. We keep
    * it as an object because its properties can change, for example the size
    * is only defined after the image is done loading.
-   * @type {olx.style.IconOptions}
+   * @type {ol.style.Icon}
    * @private
    */
   this.imageStyle_ = imageStyle;
@@ -58,7 +58,7 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
     return;
   }
 
-  var image = this.imageStyle_.getImage();
+  var image = this.imageStyle_.getImage(1);
   if (!image) {
     return;
   }

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -73,6 +73,7 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
   var anchor = this.imageStyle_.getAnchor();
   var scale = this.imageStyle_.getScale() || 1;
   var rotation = this.imageStyle_.getRotation() || 0;
+  var opacity = this.imageStyle_.getOpacity() || 1;
 
   var offsetX = anchor[0] * scale;
   var offsetY = anchor[1] * scale;
@@ -83,6 +84,7 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
   ctx.translate(x + offsetX, y + offsetY);
   ctx.rotate(rotation);
   ctx.translate(-x - offsetX, -y - offsetY);
+  ctx.globalAlpha = opacity;
 
   ctx.drawImage(image, x, y,
     image.width * scale, image.height * scale);

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -2,7 +2,7 @@
  * The following file was borrowed from the MapLabel project, which original
  * source code is available at:
  *
- *     http://google-maps-utility-library-v3.googlecode.com/svn/trunk/maplabel
+ *     https://github.com/googlemaps/js-map-label
  *
  * Here's a copy of its license:
  *

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -33,15 +33,19 @@
 
 goog.provide('olgm.gm.MapLabel');
 
+goog.require('olgm.gm.MapElement');
+
 
 /**
  * Creates a new Map Label
  * @constructor
- * @extends {google.maps.OverlayView}
+ * @extends {olgm.gm.MapElement}
  * @param {Object.<string, *>=} opt_options Optional properties to set.
  * @api
  */
 olgm.gm.MapLabel = function(opt_options) {
+  goog.base(this);
+
   this.set('font', 'normal 10px sans-serif');
   this.set('textAlign', 'center');
   this.set('textBaseline', 'middle');
@@ -50,30 +54,7 @@ olgm.gm.MapLabel = function(opt_options) {
 
   this.setValues(opt_options);
 };
-if (window.google && window.google.maps) {
-  goog.inherits(olgm.gm.MapLabel, google.maps.OverlayView);
-}
-
-
-/**
- * @type {boolean}
- * @private
- */
-olgm.gm.MapLabel.prototype.drawn_ = false;
-
-
-/**
- * @type {number}
- * @private
- */
-olgm.gm.MapLabel.prototype.height_ = 0;
-
-
-/**
- * @type {number}
- * @private
- */
-olgm.gm.MapLabel.prototype.width_ = 0;
+goog.inherits(olgm.gm.MapLabel, olgm.gm.MapElement);
 
 
 /**
@@ -165,107 +146,5 @@ olgm.gm.MapLabel.prototype.onAdd = function() {
   var panes = this.getPanes();
   if (panes) {
     panes.markerLayer.appendChild(canvas);
-  }
-};
-
-
-/**
- * Note: mark as `@api` to make the minimized version include this method.
- * @api
- */
-olgm.gm.MapLabel.prototype.draw = function() {
-
-  if (this.drawn_) {
-    this.redraw_();
-    return;
-  }
-
-  var canvas = this.canvas_;
-  if (!canvas) {
-    // onAdd has not been called yet.
-    return;
-  }
-
-  var ctx = canvas.getContext('2d');
-  var height = ctx.canvas.height;
-  var width = ctx.canvas.width;
-  this.width_ = width;
-  this.height_ = height;
-
-  if (!this.redraw_()) {
-    return;
-  }
-
-  this.drawn_ = true;
-};
-
-
-/**
- * Note: mark as `@api` to make the minimized version include this method.
- * @return {boolean} whether or not the function ran successfully
- * @private
- */
-olgm.gm.MapLabel.prototype.redraw_ = function() {
-  var latLng = /** @type {google.maps.LatLng} */ (this.get('position'));
-  if (!latLng) {
-    return false;
-  }
-
-  var projection = this.getProjection();
-  if (!projection) {
-    // The map projection is not ready yet so do nothing
-    return false;
-  }
-
-  var pos = projection.fromLatLngToDivPixel(latLng);
-  var height = this.height_;
-  var width = this.width_;
-
-  var offsetX = this.get('offsetX') || 0;
-  var offsetY = this.get('offsetY') || 0;
-  var style = this.canvas_.style;
-  style['top'] = (pos.y - (height / 2) + offsetY) + 'px';
-  style['left'] = (pos.x - (width / 2) + offsetX) + 'px';
-
-  style['visibility'] = this.getVisible_();
-
-  return true;
-};
-
-
-/**
- * Get the visibility of the label.
- * @private
- * @return {string} blank string if visible, 'hidden' if invisible.
- */
-olgm.gm.MapLabel.prototype.getVisible_ = function() {
-  var minZoom = /** @type {number} */ (this.get('minZoom'));
-  var maxZoom = /** @type {number} */ (this.get('maxZoom'));
-
-  if (minZoom === undefined && maxZoom === undefined) {
-    return '';
-  }
-
-  var map = this.getMap();
-  if (!map) {
-    return '';
-  }
-
-  var mapZoom = map.getZoom();
-  if (mapZoom < minZoom || mapZoom > maxZoom) {
-    return 'hidden';
-  }
-  return '';
-};
-
-
-/**
- * Note: mark as `@api` to make the minimized version include this method.
- * @api
- */
-olgm.gm.MapLabel.prototype.onRemove = function() {
-  var canvas = this.canvas_;
-  if (canvas && canvas.parentNode) {
-    canvas.parentNode.removeChild(canvas);
   }
 };

--- a/src/gm/mapmarker.js
+++ b/src/gm/mapmarker.js
@@ -1,0 +1,222 @@
+goog.provide('olgm.gm.MapMarker');
+
+
+/**
+ * Creates a new Map Marker
+ * @constructor
+ * @extends {google.maps.OverlayView}
+ * @param {olx.style.IconOptions} imageStyle ol3 style properties
+ * @param {Object.<string, *>=} opt_options Optional properties to set.
+ * @api
+ */
+olgm.gm.MapMarker = function(imageStyle, opt_options) {
+  this.set('zIndex', 1e3);
+  this.setValues(opt_options);
+
+  /**
+   * This object contains the ol3 style properties for the marker. We keep
+   * it as an object because its properties can change, for example the size
+   * is only defined after the image is done loading.
+   * @type {olx.style.IconOptions}
+   * @private
+   */
+  this.imageStyle_ = imageStyle;
+};
+if (window.google && window.google.maps) {
+  goog.inherits(olgm.gm.MapMarker, google.maps.OverlayView);
+}
+
+
+/**
+ * @type {boolean}
+ * @private
+ */
+olgm.gm.MapMarker.prototype.drawn_ = false;
+
+
+/**
+ * @type {number}
+ * @private
+ */
+olgm.gm.MapMarker.prototype.height_ = 0;
+
+
+/**
+ * @type {number}
+ * @private
+ */
+olgm.gm.MapMarker.prototype.width_ = 0;
+
+
+/**
+ * Listen to property changes and react accordingly
+ * @param {string} prop property
+ * @api
+ */
+olgm.gm.MapMarker.prototype.changed = function(prop) {
+  switch (prop) {
+    case 'maxZoom':
+    case 'minZoom':
+    case 'offsetX':
+    case 'offsetY':
+    case 'position':
+      this.draw();
+      break;
+    default:
+      break;
+  }
+};
+
+
+/**
+ * Draws the label to the canvas 2d context.
+ * @private
+ */
+olgm.gm.MapMarker.prototype.drawCanvas_ = function() {
+  var canvas = this.canvas_;
+  if (!canvas) {
+    return;
+  }
+
+  var image = this.imageStyle_.getImage();
+  if (!image) {
+    return;
+  }
+
+  var style = canvas.style;
+
+  style.zIndex = /** @type {number} */ (this.get('zIndex'));
+
+  var ctx = canvas.getContext('2d');
+  ctx.clearRect(0,0,canvas.width, canvas.height);
+
+  var anchor = this.imageStyle_.getAnchor();
+
+  var offsetX = anchor[0];
+  var offsetY = anchor[1];
+
+  var x = canvas.width / 2 - offsetX;
+  var y = canvas.height / 2 - offsetY;
+  ctx.drawImage(image, x, y);
+};
+
+
+/**
+ * Manage feature being added to the map
+ * @api
+ */
+olgm.gm.MapMarker.prototype.onAdd = function() {
+  var canvas = this.canvas_ = document.createElement('canvas');
+  var style = canvas.style;
+  style.position = 'absolute';
+
+  this.drawCanvas_();
+
+  var panes = this.getPanes();
+  if (panes) {
+    panes.markerLayer.appendChild(canvas);
+  }
+};
+
+
+/**
+ * Draw features to the map (call redraw) and setup canvas if it's the first
+ * time we draw
+ * @api
+ */
+olgm.gm.MapMarker.prototype.draw = function() {
+  if (this.drawn_) {
+    this.redraw_();
+    return;
+  }
+
+  var canvas = this.canvas_;
+  if (!canvas) {
+    // onAdd has not been called yet.
+    return;
+  }
+
+  var ctx = canvas.getContext('2d');
+  var height = ctx.canvas.height;
+  var width = ctx.canvas.width;
+  this.width_ = width;
+  this.height_ = height;
+
+  if (!this.redraw_()) {
+    return;
+  }
+
+  this.drawn_ = true;
+};
+
+
+/**
+ * Redraw features to the map
+ * @return {boolean} whether or not the function ran successfully
+ * @private
+ */
+olgm.gm.MapMarker.prototype.redraw_ = function() {
+  var latLng = /** @type {google.maps.LatLng} */ (this.get('position'));
+  if (!latLng) {
+    return false;
+  }
+
+  var projection = this.getProjection();
+  if (!projection) {
+    // The map projection is not ready yet so do nothing
+    return false;
+  }
+
+  var pos = projection.fromLatLngToDivPixel(latLng);
+  var height = this.height_;
+  var width = this.width_;
+
+  var offsetX = this.get('offsetX') || 0;
+  var offsetY = this.get('offsetY') || 0;
+
+  var style = this.canvas_.style;
+  style['top'] = (pos.y - (height / 2) + offsetY) + 'px';
+  style['left'] = (pos.x - (width / 2) + offsetX) + 'px';
+
+  style['visibility'] = this.getVisible_();
+
+  return true;
+};
+
+
+/**
+ * Get the visibility of the label.
+ * @private
+ * @return {string} blank string if visible, 'hidden' if invisible.
+ */
+olgm.gm.MapMarker.prototype.getVisible_ = function() {
+  var minZoom = /** @type {number} */ (this.get('minZoom'));
+  var maxZoom = /** @type {number} */ (this.get('maxZoom'));
+
+  if (minZoom === undefined && maxZoom === undefined) {
+    return '';
+  }
+
+  var map = this.getMap();
+  if (!map) {
+    return '';
+  }
+
+  var mapZoom = map.getZoom();
+  if (mapZoom < minZoom || mapZoom > maxZoom) {
+    return 'hidden';
+  }
+  return '';
+};
+
+
+/**
+ * Delete canvas when removing the marker
+ * @api
+ */
+olgm.gm.MapMarker.prototype.onRemove = function() {
+  var canvas = this.canvas_;
+  if (canvas && canvas.parentNode) {
+    canvas.parentNode.removeChild(canvas);
+  }
+};

--- a/src/gm/mapmarker.js
+++ b/src/gm/mapmarker.js
@@ -1,17 +1,18 @@
 goog.provide('olgm.gm.MapMarker');
 
+goog.require('olgm.gm.MapElement');
+
 
 /**
  * Creates a new Map Marker
  * @constructor
- * @extends {google.maps.OverlayView}
+ * @extends {olgm.gm.MapElement}
  * @param {olx.style.IconOptions} imageStyle ol3 style properties
  * @param {Object.<string, *>=} opt_options Optional properties to set.
  * @api
  */
 olgm.gm.MapMarker = function(imageStyle, opt_options) {
-  this.set('zIndex', 1e3);
-  this.setValues(opt_options);
+  goog.base(this);
 
   /**
    * This object contains the ol3 style properties for the marker. We keep
@@ -21,31 +22,10 @@ olgm.gm.MapMarker = function(imageStyle, opt_options) {
    * @private
    */
   this.imageStyle_ = imageStyle;
+
+  this.setValues(opt_options);
 };
-if (window.google && window.google.maps) {
-  goog.inherits(olgm.gm.MapMarker, google.maps.OverlayView);
-}
-
-
-/**
- * @type {boolean}
- * @private
- */
-olgm.gm.MapMarker.prototype.drawn_ = false;
-
-
-/**
- * @type {number}
- * @private
- */
-olgm.gm.MapMarker.prototype.height_ = 0;
-
-
-/**
- * @type {number}
- * @private
- */
-olgm.gm.MapMarker.prototype.width_ = 0;
+goog.inherits(olgm.gm.MapMarker, olgm.gm.MapElement);
 
 
 /**
@@ -69,7 +49,7 @@ olgm.gm.MapMarker.prototype.changed = function(prop) {
 
 
 /**
- * Draws the label to the canvas 2d context.
+ * Draws the marker to the canvas 2d context.
  * @private
  */
 olgm.gm.MapMarker.prototype.drawCanvas_ = function() {
@@ -115,108 +95,5 @@ olgm.gm.MapMarker.prototype.onAdd = function() {
   var panes = this.getPanes();
   if (panes) {
     panes.markerLayer.appendChild(canvas);
-  }
-};
-
-
-/**
- * Draw features to the map (call redraw) and setup canvas if it's the first
- * time we draw
- * @api
- */
-olgm.gm.MapMarker.prototype.draw = function() {
-  if (this.drawn_) {
-    this.redraw_();
-    return;
-  }
-
-  var canvas = this.canvas_;
-  if (!canvas) {
-    // onAdd has not been called yet.
-    return;
-  }
-
-  var ctx = canvas.getContext('2d');
-  var height = ctx.canvas.height;
-  var width = ctx.canvas.width;
-  this.width_ = width;
-  this.height_ = height;
-
-  if (!this.redraw_()) {
-    return;
-  }
-
-  this.drawn_ = true;
-};
-
-
-/**
- * Redraw features to the map
- * @return {boolean} whether or not the function ran successfully
- * @private
- */
-olgm.gm.MapMarker.prototype.redraw_ = function() {
-  var latLng = /** @type {google.maps.LatLng} */ (this.get('position'));
-  if (!latLng) {
-    return false;
-  }
-
-  var projection = this.getProjection();
-  if (!projection) {
-    // The map projection is not ready yet so do nothing
-    return false;
-  }
-
-  var pos = projection.fromLatLngToDivPixel(latLng);
-  var height = this.height_;
-  var width = this.width_;
-
-  var offsetX = this.get('offsetX') || 0;
-  var offsetY = this.get('offsetY') || 0;
-
-  var style = this.canvas_.style;
-  style['top'] = (pos.y - (height / 2) + offsetY) + 'px';
-  style['left'] = (pos.x - (width / 2) + offsetX) + 'px';
-
-  style['visibility'] = this.getVisible_();
-
-  return true;
-};
-
-
-/**
- * Get the visibility of the label.
- * @private
- * @return {string} blank string if visible, 'hidden' if invisible.
- */
-olgm.gm.MapMarker.prototype.getVisible_ = function() {
-  var minZoom = /** @type {number} */ (this.get('minZoom'));
-  var maxZoom = /** @type {number} */ (this.get('maxZoom'));
-
-  if (minZoom === undefined && maxZoom === undefined) {
-    return '';
-  }
-
-  var map = this.getMap();
-  if (!map) {
-    return '';
-  }
-
-  var mapZoom = map.getZoom();
-  if (mapZoom < minZoom || mapZoom > maxZoom) {
-    return 'hidden';
-  }
-  return '';
-};
-
-
-/**
- * Delete canvas when removing the marker
- * @api
- */
-olgm.gm.MapMarker.prototype.onRemove = function() {
-  var canvas = this.canvas_;
-  if (canvas && canvas.parentNode) {
-    canvas.parentNode.removeChild(canvas);
   }
 };

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -103,7 +103,8 @@ olgm.herald.Feature.prototype.activate = function() {
     var index = zIndex !== undefined ? zIndex : this.index_;
 
     var image = style.getImage();
-    var useCanvas = this.mapIconOptions_.useCanvas;
+    var useCanvas = this.mapIconOptions_.useCanvas !== undefined ?
+        this.mapIconOptions_.useCanvas : false;
     if (image && image instanceof ol.style.Icon && useCanvas) {
       this.marker_ = olgm.gm.createMapIcon(image, latLng, index);
       this.marker_.setMap(this.gmap);

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -105,7 +105,7 @@ olgm.herald.Feature.prototype.activate = function() {
     var image = style.getImage();
     var useCanvas = this.mapIconOptions_.useCanvas;
     if (image && image instanceof ol.style.Icon && useCanvas) {
-      this.marker_ = olgm.gm.createMarker(image, latLng, index);
+      this.marker_ = olgm.gm.createMapIcon(image, latLng, index);
       this.marker_.setMap(this.gmap);
     }
 

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -87,15 +87,18 @@ olgm.herald.Feature.prototype.activate = function() {
   var style = olgm.getStyleOf(this.feature_);
 
   if (style) {
+    var zIndex = style.getZIndex();
+    var index = zIndex !== undefined ? zIndex : this.index_;
+
     var image = style.getImage();
     if (image && image instanceof ol.style.Icon) {
-      this.marker_ = olgm.gm.createMarker(image, latLng, this.index_);
+      this.marker_ = olgm.gm.createMarker(image, latLng, index);
       this.marker_.setMap(this.gmap);
     }
 
     var text = style.getText();
     if (text) {
-      this.label_ = olgm.gm.createLabel(text, latLng, this.index_);
+      this.label_ = olgm.gm.createLabel(text, latLng, index);
       this.label_.setMap(this.gmap);
     }
   }

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -40,10 +40,10 @@ olgm.herald.Feature = function(ol3map, gmap, options) {
   this.index_ = options.index;
 
   /**
-   * @type {boolean}
+   * @type {olgmx.gm.MapIconOptions}
    * @private
    */
-  this.useCanvas_ = options.useCanvas;
+  this.mapIconOptions_ = options.mapIconOptions;
 
   goog.base(this, ol3map, gmap);
 
@@ -66,7 +66,7 @@ olgm.herald.Feature.prototype.label_ = null;
 
 /**
  * The marker object contains a marker to draw on a canvas instead of using
- * the Google Maps API. If useCanvas_ is set to false, this variable won't 
+ * the Google Maps API. If useCanvas_ is set to false, this variable won't
  * be used.
  * @type {olgm.gm.MapIcon}
  * @private
@@ -88,7 +88,8 @@ olgm.herald.Feature.prototype.activate = function() {
   this.data_.add(this.gmapFeature_);
 
   // override style if a style is defined at the feature level
-  var gmStyle = olgm.gm.createStyle(this.feature_, this.useCanvas_, this.index_);
+  var gmStyle = olgm.gm.createStyle(
+      this.feature_, this.mapIconOptions_, this.index_);
   if (gmStyle) {
     this.data_.overrideStyle(this.gmapFeature_, gmStyle);
   }
@@ -102,7 +103,8 @@ olgm.herald.Feature.prototype.activate = function() {
     var index = zIndex !== undefined ? zIndex : this.index_;
 
     var image = style.getImage();
-    if (image && image instanceof ol.style.Icon && this.useCanvas_) {
+    var useCanvas = this.mapIconOptions_.useCanvas;
+    if (image && image instanceof ol.style.Icon && useCanvas) {
       this.marker_ = olgm.gm.createMarker(image, latLng, index);
       this.marker_.setMap(this.gmap);
     }

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -60,6 +60,8 @@ olgm.herald.Feature.prototype.gmapFeature_ = null;
  */
 olgm.herald.Feature.prototype.label_ = null;
 
+olgm.herald.Feature.prototype.marker_ = null;
+
 
 /**
  * @inheritDoc
@@ -81,11 +83,18 @@ olgm.herald.Feature.prototype.activate = function() {
   }
 
   // if the feature has text style, add a map label to gmap
+  var latLng = olgm.gm.createLatLng(olgm.getCenterOf(geometry));
   var style = olgm.getStyleOf(this.feature_);
+
   if (style) {
+    var image = style.getImage();
+    if (image && image instanceof ol.style.Icon) {
+      this.marker_ = olgm.gm.createMarker(image, latLng, this.index_);
+      this.marker_.setMap(this.gmap);
+    }
+
     var text = style.getText();
     if (text) {
-      var latLng = olgm.gm.createLatLng(olgm.getCenterOf(geometry));
       this.label_ = olgm.gm.createLabel(text, latLng, this.index_);
       this.label_.setMap(this.gmap);
     }
@@ -113,6 +122,12 @@ olgm.herald.Feature.prototype.deactivate = function() {
   this.data_.remove(this.gmapFeature_);
   this.gmapFeature_ = null;
 
+  // remove feature
+  if (this.marker_) {
+    this.marker_.setMap(null);
+    this.marker_ = null;
+  }
+
   // remove label
   if (this.label_) {
     this.label_.setMap(null);
@@ -131,9 +146,16 @@ olgm.herald.Feature.prototype.handleGeometryChange_ = function() {
   goog.asserts.assertInstanceof(geometry, ol.geom.Geometry);
   this.gmapFeature_.setGeometry(olgm.gm.createFeatureGeometry(geometry));
 
+  var latLng;
+
   if (this.label_) {
-    var latLng = olgm.gm.createLatLng(olgm.getCenterOf(geometry));
+    latLng = olgm.gm.createLatLng(olgm.getCenterOf(geometry));
     this.label_.set('position', latLng);
+  }
+
+  if (this.marker_) {
+    latLng = olgm.gm.createLatLng(olgm.getCenterOf(geometry));
+    this.marker_.set('position', latLng);
   }
 };
 

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -15,31 +15,35 @@ goog.require('olgm.herald.Herald');
  *
  * @param {!ol.Map} ol3map openlayers map
  * @param {!google.maps.Map} gmap google maps map
- * @param {ol.Feature} feature feature to synchronise
- * @param {!google.maps.Data} data google maps data
- * @param {number} index feature index
+ * @param {olgmx.herald.FeatureOptions} options options
  * @constructor
  * @extends {olgm.herald.Herald}
  */
-olgm.herald.Feature = function(ol3map, gmap, feature, data, index) {
+olgm.herald.Feature = function(ol3map, gmap, options) {
 
   /**
    * @type {ol.Feature}
    * @private
    */
-  this.feature_ = feature;
+  this.feature_ = options.feature;
 
   /**
    * @type {!google.maps.Data}
    * @private
    */
-  this.data_ = data;
+  this.data_ = options.data;
 
   /**
    * @type {number}
    * @private
    */
-  this.index_ = index;
+  this.index_ = options.index;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.useCanvas_ = options.useCanvas;
 
   goog.base(this, ol3map, gmap);
 
@@ -60,6 +64,13 @@ olgm.herald.Feature.prototype.gmapFeature_ = null;
  */
 olgm.herald.Feature.prototype.label_ = null;
 
+/**
+ * The marker object contains a marker to draw on a canvas instead of using
+ * the Google Maps API. If useCanvas_ is set to false, this variable won't 
+ * be used.
+ * @type {olgm.gm.MapIcon}
+ * @private
+ */
 olgm.herald.Feature.prototype.marker_ = null;
 
 
@@ -77,7 +88,7 @@ olgm.herald.Feature.prototype.activate = function() {
   this.data_.add(this.gmapFeature_);
 
   // override style if a style is defined at the feature level
-  var gmStyle = olgm.gm.createStyle(this.feature_, this.index_);
+  var gmStyle = olgm.gm.createStyle(this.feature_, this.useCanvas_, this.index_);
   if (gmStyle) {
     this.data_.overrideStyle(this.gmapFeature_, gmStyle);
   }
@@ -91,7 +102,7 @@ olgm.herald.Feature.prototype.activate = function() {
     var index = zIndex !== undefined ? zIndex : this.index_;
 
     var image = style.getImage();
-    if (image && image instanceof ol.style.Icon) {
+    if (image && image instanceof ol.style.Icon && this.useCanvas_) {
       this.marker_ = olgm.gm.createMarker(image, latLng, index);
       this.marker_.setMap(this.gmap);
     }

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -43,10 +43,13 @@ goog.require('olgm.layer.Google');
  * @param {!ol.Map} ol3map openlayers map
  * @param {!google.maps.Map} gmap google maps map
  * @param {boolean} watchVector whether we should watch vector layers or not
+ * @param {boolean} useCanvas whether or not we should draw on canvases when
+ * we can, instead of using the Google Maps API. This fixes z-index issues
+ * with labels on markers
  * @constructor
  * @extends {olgm.herald.Herald}
  */
-olgm.herald.Layers = function(ol3map, gmap, watchVector) {
+olgm.herald.Layers = function(ol3map, gmap, watchVector, useCanvas) {
 
   /**
    * @type {Array.<olgm.layer.Google>}
@@ -76,7 +79,7 @@ olgm.herald.Layers = function(ol3map, gmap, watchVector) {
    * @type {olgm.herald.VectorSource}
    * @private
    */
-  this.vectorSourceHerald_ = new olgm.herald.VectorSource(ol3map, gmap);
+  this.vectorSourceHerald_ = new olgm.herald.VectorSource(ol3map, gmap, useCanvas);
 
   /**
    * @type {olgm.herald.View}

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -43,13 +43,11 @@ goog.require('olgm.layer.Google');
  * @param {!ol.Map} ol3map openlayers map
  * @param {!google.maps.Map} gmap google maps map
  * @param {boolean} watchVector whether we should watch vector layers or not
- * @param {boolean} useCanvas whether or not we should draw on canvases when
- * we can, instead of using the Google Maps API. This fixes z-index issues
- * with labels on markers
+ * @param {olgmx.gm.MapIconOptions} mapIconOptions map icon options
  * @constructor
  * @extends {olgm.herald.Herald}
  */
-olgm.herald.Layers = function(ol3map, gmap, watchVector, useCanvas) {
+olgm.herald.Layers = function(ol3map, gmap, watchVector, mapIconOptions) {
 
   /**
    * @type {Array.<olgm.layer.Google>}
@@ -79,7 +77,8 @@ olgm.herald.Layers = function(ol3map, gmap, watchVector, useCanvas) {
    * @type {olgm.herald.VectorSource}
    * @private
    */
-  this.vectorSourceHerald_ = new olgm.herald.VectorSource(ol3map, gmap, useCanvas);
+  this.vectorSourceHerald_ = new olgm.herald.VectorSource(
+      ol3map, gmap, mapIconOptions);
 
   /**
    * @type {olgm.herald.View}

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -15,10 +15,13 @@ goog.require('olgm.herald.Herald');
  * @param {!google.maps.Map} gmap google maps map
  * @param {!ol.source.Vector} source vector source
  * @param {!google.maps.Data} data google maps data object
+ * @param {boolean} useCanvas whether or not we should draw on canvases when
+ * we can, instead of using the Google Maps API. This fixes z-index issues
+ * with labels on markers
  * @constructor
  * @extends {olgm.herald.Herald}
  */
-olgm.herald.VectorFeature = function(ol3map, gmap, source, data) {
+olgm.herald.VectorFeature = function(ol3map, gmap, source, data, useCanvas) {
 
   /**
    * @type {Array.<ol.Feature>}
@@ -43,6 +46,12 @@ olgm.herald.VectorFeature = function(ol3map, gmap, source, data) {
    * @private
    */
   this.source_ = source;
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.useCanvas_ = useCanvas;
 
   goog.base(this, ol3map, gmap);
 };
@@ -114,7 +123,13 @@ olgm.herald.VectorFeature.prototype.watchFeature_ = function(feature) {
   var index = this.features_.indexOf(feature);
 
   // create and activate feature herald
-  var herald = new olgm.herald.Feature(ol3map, gmap, feature, data, index);
+  var options = {
+    feature: feature,
+    data: data,
+    index: index,
+    useCanvas: this.useCanvas_
+  };
+  var herald = new olgm.herald.Feature(ol3map, gmap, options);
   herald.activate();
 
   // push to cache

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -15,13 +15,12 @@ goog.require('olgm.herald.Herald');
  * @param {!google.maps.Map} gmap google maps map
  * @param {!ol.source.Vector} source vector source
  * @param {!google.maps.Data} data google maps data object
- * @param {boolean} useCanvas whether or not we should draw on canvases when
- * we can, instead of using the Google Maps API. This fixes z-index issues
- * with labels on markers
+ * @param {olgmx.gm.MapIconOptions} mapIconOptions map icon options
  * @constructor
  * @extends {olgm.herald.Herald}
  */
-olgm.herald.VectorFeature = function(ol3map, gmap, source, data, useCanvas) {
+olgm.herald.VectorFeature = function(
+    ol3map, gmap, source, data, mapIconOptions) {
 
   /**
    * @type {Array.<ol.Feature>}
@@ -48,10 +47,10 @@ olgm.herald.VectorFeature = function(ol3map, gmap, source, data, useCanvas) {
   this.source_ = source;
 
   /**
-   * @type {boolean}
+   * @type {olgmx.gm.MapIconOptions}
    * @private
    */
-  this.useCanvas_ = useCanvas;
+  this.mapIconOptions_ = mapIconOptions;
 
   goog.base(this, ol3map, gmap);
 };
@@ -127,7 +126,7 @@ olgm.herald.VectorFeature.prototype.watchFeature_ = function(feature) {
     feature: feature,
     data: data,
     index: index,
-    useCanvas: this.useCanvas_
+    mapIconOptions: this.mapIconOptions_
   };
   var herald = new olgm.herald.Feature(ol3map, gmap, options);
   herald.activate();

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -8,13 +8,11 @@ goog.require('olgm.herald.VectorFeature');
  * Listen to a Vector layer
  * @param {!ol.Map} ol3map openlayers map
  * @param {!google.maps.Map} gmap google maps map
- * @param {boolean} useCanvas whether or not we should draw on canvases when
- * we can, instead of using the Google Maps API. This fixes z-index issues
- * with labels on markers
+ * @param {olgmx.gm.MapIconOptions} mapIconOptions map icon options
  * @constructor
  * @extends {olgm.herald.Source}
  */
-olgm.herald.VectorSource = function(ol3map, gmap, useCanvas) {
+olgm.herald.VectorSource = function(ol3map, gmap, mapIconOptions) {
   /**
   * @type {Array.<olgm.herald.VectorSource.LayerCache>}
   * @private
@@ -28,10 +26,10 @@ olgm.herald.VectorSource = function(ol3map, gmap, useCanvas) {
   this.layers_ = [];
 
   /**
-   * @type {boolean}
+   * @type {olgmx.gm.MapIconOptions}
    * @private
    */
-  this.useCanvas_ = useCanvas;
+  this.mapIconOptions_ = mapIconOptions;
 
   goog.base(this, ol3map, gmap);
 };
@@ -60,14 +58,14 @@ olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
   });
 
   // Style
-  var gmStyle = olgm.gm.createStyle(vectorLayer, this.useCanvas_);
+  var gmStyle = olgm.gm.createStyle(vectorLayer, this.mapIconOptions_);
   if (gmStyle) {
     data.setStyle(gmStyle);
   }
 
   // herald
   var herald = new olgm.herald.VectorFeature(
-      this.ol3map, this.gmap, source, data, this.useCanvas_);
+      this.ol3map, this.gmap, source, data, this.mapIconOptions_);
 
   // opacity
   var opacity = vectorLayer.getOpacity();

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -8,10 +8,13 @@ goog.require('olgm.herald.VectorFeature');
  * Listen to a Vector layer
  * @param {!ol.Map} ol3map openlayers map
  * @param {!google.maps.Map} gmap google maps map
+ * @param {boolean} useCanvas whether or not we should draw on canvases when
+ * we can, instead of using the Google Maps API. This fixes z-index issues
+ * with labels on markers
  * @constructor
  * @extends {olgm.herald.Source}
  */
-olgm.herald.VectorSource = function(ol3map, gmap) {
+olgm.herald.VectorSource = function(ol3map, gmap, useCanvas) {
   /**
   * @type {Array.<olgm.herald.VectorSource.LayerCache>}
   * @private
@@ -23,6 +26,12 @@ olgm.herald.VectorSource = function(ol3map, gmap) {
   * @private
   */
   this.layers_ = [];
+
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.useCanvas_ = useCanvas;
 
   goog.base(this, ol3map, gmap);
 };
@@ -51,14 +60,14 @@ olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
   });
 
   // Style
-  var gmStyle = olgm.gm.createStyle(vectorLayer);
+  var gmStyle = olgm.gm.createStyle(vectorLayer, this.useCanvas_);
   if (gmStyle) {
     data.setStyle(gmStyle);
   }
 
   // herald
   var herald = new olgm.herald.VectorFeature(
-      this.ol3map, this.gmap, source, data);
+      this.ol3map, this.gmap, source, data, this.useCanvas_);
 
   // opacity
   var opacity = vectorLayer.getOpacity();

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -64,12 +64,14 @@ olgm.OLGoogleMaps = function(options) {
   var watchVector = options.watchVector !== undefined ?
       options.watchVector : true;
 
+  var useCanvas = options.useCanvas !== undefined ? options.useCanvas : false;
+
   /**
    * @type {olgm.herald.Layers}
    * @private
    */
   this.layersHerald_ = new olgm.herald.Layers(
-      this.ol3map, this.gmap, watchVector);
+      this.ol3map, this.gmap, watchVector, useCanvas);
   this.heralds_.push(this.layersHerald_);
 };
 goog.inherits(olgm.OLGoogleMaps, olgm.Abstract);

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -65,7 +65,7 @@ olgm.OLGoogleMaps = function(options) {
       options.watchVector : true;
 
   var mapIconOptions = options.mapIconOptions !== undefined ?
-      options.mapIconOptions : {useCanvas: false};
+      options.mapIconOptions : {};
 
   /**
    * @type {olgm.herald.Layers}

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -64,14 +64,15 @@ olgm.OLGoogleMaps = function(options) {
   var watchVector = options.watchVector !== undefined ?
       options.watchVector : true;
 
-  var useCanvas = options.useCanvas !== undefined ? options.useCanvas : false;
+  var mapIconOptions = options.mapIconOptions !== undefined ?
+      options.mapIconOptions : {useCanvas: false};
 
   /**
    * @type {olgm.herald.Layers}
    * @private
    */
   this.layersHerald_ = new olgm.herald.Layers(
-      this.ol3map, this.gmap, watchVector, useCanvas);
+      this.ol3map, this.gmap, watchVector, mapIconOptions);
   this.heralds_.push(this.layersHerald_);
 };
 goog.inherits(olgm.OLGoogleMaps, olgm.Abstract);


### PR DESCRIPTION
This PR makes Google Maps render markers with a canvas, on an OverlayView. This works the same way that MapLabel does, and they both inherit from a generic MapElement class.

This allows setting the zIndex in a way that works with the text labels object. It also allows setting properties such as opacity for the markers. Examples label.html and icon.html have been modified to demonstrate these features.
