### PR TITLE
Fix #89 - Support ol.style.RegularShape

### DIFF
--- a/examples/regularshape.html
+++ b/examples/regularshape.html
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps regular shapes example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Regular shapes</h4>
+          <p>
+            This example demonstrates regular shapes being drawn on Google Maps.
+            This is done by building a SVG path from the ol.style.RegularShape
+            attributes, and sending it to Google Maps.
+          </p>
+
+          <input id="toggleOSM" type="button" onclick="toggleOSM();"
+                 value="Toggle between OL3 and GMAPS" />
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3&key=mykey
+         where mykey is your Google Maps API key -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3"></script>
+
+    <script src="/@loader"></script>
+    <script src="regularshape.js"></script>
+  </body>
+</html>

--- a/examples/regularshape.js
+++ b/examples/regularshape.js
@@ -1,0 +1,106 @@
+var center = [-7908084, 6177492];
+
+// This dummy layer tells Google Maps to switch to its default map type
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var stroke = new ol.style.Stroke({color: 'black', width: 2});
+
+var styles = {
+  'square': [new ol.style.Style({
+    image: new ol.style.RegularShape({
+      fill: new ol.style.Fill({color: 'red'}),
+      stroke: stroke,
+      points: 4,
+      radius: 10,
+      angle: Math.PI / 4
+    })
+  })],
+  'triangle': [new ol.style.Style({
+    image: new ol.style.RegularShape({
+      fill: new ol.style.Fill({color: 'yellow'}),
+      stroke: stroke,
+      points: 3,
+      radius: 10,
+      rotation: Math.PI / 4,
+      angle: 0
+    })
+  })],
+  'star': [new ol.style.Style({
+    image: new ol.style.RegularShape({
+      fill: new ol.style.Fill({color: 'green'}),
+      stroke: stroke,
+      points: 5,
+      radius: 10,
+      radius2: 4,
+      angle: 0
+    })
+  })],
+  'pentagon': [new ol.style.Style({
+    image: new ol.style.RegularShape({
+      fill: new ol.style.Fill({color: 'blue'}),
+      stroke: stroke,
+      points: 5,
+      radius: 10,
+      angle: 0,
+    })
+  })],
+  'x': [new ol.style.Style({
+    image: new ol.style.RegularShape({
+      stroke: stroke,
+      points: 4,
+      radius: 10,
+      radius2: 0,
+      angle: Math.PI / 4
+    })
+  })]
+};
+
+
+var styleKeys = ['x', 'pentagon', 'star', 'triangle', 'square'];
+var count = 50;
+var features = new Array(count);
+var spread = 20000;
+for (var i = 0; i < count; ++i) {
+  var x = center[0]-(spread/2) + Math.random()*spread;
+  var y = center[1]-(spread/2) + Math.random()*spread;
+  var coordinates = [x, y];
+  features[i] = new ol.Feature(new ol.geom.Point(coordinates));
+  var style = styles[styleKeys[Math.floor(Math.random() * 5)]][0];
+  features[i].setStyle(style);
+}
+
+var source = new ol.source.Vector({
+  features: features
+});
+
+var vectorLayer = new ol.layer.Vector({
+  source: source
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    vectorLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 12
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+function toggleOSM() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -185,9 +185,40 @@ olgm.gm.createStyleInternal = function(style, mapIconOptions, opt_index) {
     var useCanvas = mapIconOptions.useCanvas !== undefined ?
         mapIconOptions.useCanvas : false;
 
-    if (image instanceof ol.style.Circle) {
+    if (image instanceof ol.style.Circle ||
+        image instanceof ol.style.RegularShape) {
       // --- ol.style.Circle ---
-      gmSymbol['path'] = google.maps.SymbolPath.CIRCLE;
+      if (image instanceof ol.style.Circle) {
+        gmSymbol['path'] = google.maps.SymbolPath.CIRCLE;
+      } else if (image instanceof ol.style.RegularShape) {
+        // Google Maps support SVG Paths. We'll build one manually.
+        var path = 'M ';
+
+        // Get a few variables from the image style;
+        var nbPoints = image.getPoints();
+        var outerRadius = image.getRadius();
+        var innerRadius = image.getRadius2() !== undefined ?
+            image.getRadius2() : image.getRadius();
+        var size = 0.1;
+        var rotation = image.getRotation() + image.getAngle();
+
+        if (innerRadius == 0) {
+          nbPoints = nbPoints / 2;
+        }
+
+        for (var i = 0; i < nbPoints; i++) {
+          var radius = i % 2 == 0 ? outerRadius : innerRadius;
+          var angle = (i * 2 * Math.PI / nbPoints) - (Math.PI / 2) + rotation;
+
+          var x = size * radius * Math.cos(angle);
+          var y = size * radius * Math.sin(angle);
+          path += x + ',' + y + ' ';
+        }
+
+        // Close the path
+        path += 'Z';
+        gmSymbol['path'] = path;
+      }
 
       var imageStroke = image.getStroke();
       if (imageStroke) {


### PR DESCRIPTION
This fix lets us uses ol.style.RegularShape, as requested in issue #89. To do this, we convert the RegularShape to a SVG path by appending to a string the coordinates of every point of the polygon. 
