### PR TITLE
Add basic support for map rotation

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -69,7 +69,7 @@ rendered directly in Google Maps for a smooth effect while interacting the map:
  * `ol.layer.Vector`
  * `olgm.layer.Google`
  * `ol.layer.Image` with `ol.source.ImageWMS`
- * `ol.layer.Tile` with `ol.source.TileWMS`, `ol.source.WMTS` and 
+ * `ol.layer.Tile` with `ol.source.TileWMS`, `ol.source.WMTS` and
  `ol.source.XYZ`
 
 All the other layers currently stay in OpenLayers, on top of Google Maps.
@@ -81,12 +81,16 @@ Rotation
 --------
 
 OpenLayers 3 supports rotating the map in a 'free' way, i.e. the view of the
-map can be rotated in any direction, in any angle.  Google Maps also supports
-rotating the map, but not as freely.  For that reason, it is not recommended
-to allow your maps to be rotated at all when using this library.
+map can be rotated in any direction, in any angle. Google Maps' API only
+allows rotating the map in increments of 90 degrees.
+
+There is a workaround implemented to rotate the div containing the Google Maps
+map, which should be enough for basic rotation support, but it won't be
+perfectly functional until Google Maps implements a way to rotate the map
+freely in their API.
 
 Recommendation: use `interactions: olgm.interactions.defaults()` in your OL3
-map options, in which the interations that allow rotating the map are not
+map options, in which the interactions that allow rotating the map are not
 included.
 
 

--- a/examples/rotation.html
+++ b/examples/rotation.html
@@ -24,6 +24,9 @@
           <p>
             Demonstrates the support of rotated maps with OL3-Google-Maps.
           </p>
+          <p>
+            Use Alt + Shift + Drag to rotate the map.
+          </p>
 
           <input id="toggle" type="button" onclick="toggle();"
                  value="Toggle Between OL3 and GMAPS" />

--- a/examples/rotation.html
+++ b/examples/rotation.html
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps rotation example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Rotation example</h4>
+          <p>
+            Demonstrates the support of rotated maps with OL3-Google-Maps.
+          </p>
+
+          <input id="toggle" type="button" onclick="toggle();"
+                 value="Toggle Between OL3 and GMAPS" />
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3&key=mykey
+         where mykey is your Google Maps API key -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3"></script>
+
+    <script src="/@loader"></script>
+    <script src="rotation.js"></script>
+  </body>
+</html>

--- a/examples/rotation.js
+++ b/examples/rotation.js
@@ -1,0 +1,60 @@
+var center = [-7908084, 6177492];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var source = new ol.source.Vector();
+var feature = new ol.Feature(new ol.geom.Point(center));
+feature.setStyle(new ol.style.Style({
+    image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+      anchor: [0.5, 46],
+      anchorXUnits: 'fraction',
+      anchorYUnits: 'pixels',
+      size: [32, 48],
+      scale: 0.75,
+      src: 'data/icon.png',
+      rotation: 0.25 * Math.PI,
+      opacity: 0.5
+    }))
+  }));
+source.addFeature(feature);
+var vector = new ol.layer.Vector({
+  source: source
+});
+
+var interactionOptions = {'dragPan': false};
+var interactions = ol.interaction.defaults(interactionOptions).extend([
+  new ol.interaction.DragPan()
+]);
+
+var map = new ol.Map({
+  interactions: interactions,
+  layers: [
+    googleLayer,
+    osmLayer,
+    vector
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    rotation: Math.PI / 3,
+    zoom: 12
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({
+  map: map,
+  mapIconOptions: {
+    useCanvas: true
+  }}); // map is the ol.Map instance
+olGM.activate();
+
+
+function toggle() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -335,6 +335,7 @@ olgm.herald.Layers.prototype.activateGoogleMaps_ = function() {
   // it's also possible that the google maps map is not exactly at the
   // correct location. Fix this manually here
   this.viewHerald_.setCenter();
+  this.viewHerald_.setRotation();
   this.viewHerald_.setZoom();
 
   this.setGoogleMapsActive_(true);


### PR DESCRIPTION
This commit adds basic support for map rotation in Google Maps. The default interactions still disable it, because it has a few small issues: when the map is rotated, resize events don't work well, and the google attribution tends to disappear when switching from ol3 to google maps.
