### PR TITLE
Support minResolution and maxResolution

### DIFF
--- a/examples/min-max-resolution.html
+++ b/examples/min-max-resolution.html
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps Min/Max resolution example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Min/Max resolution example</h4>
+          <p>
+            In this example, the three layers are only visible in two zoom
+            levels, thanks to the minResolution and maxResolution layer
+            attributes.
+          </p>
+
+          <input id="toggleOSM" type="button" onclick="toggleOSM();"
+                 value="Toggle between OL3 and GMAPS" />
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3&key=mykey
+         where mykey is your Google Maps API key -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3"></script>
+
+    <script src="/@loader"></script>
+    <script src="min-max-resolution.js"></script>
+  </body>
+</html>

--- a/examples/min-max-resolution.js
+++ b/examples/min-max-resolution.js
@@ -1,0 +1,79 @@
+var center = [-10997148, 4569099];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var tileJSONLayer = new ol.layer.Tile({
+  source: new ol.source.TileJSON({
+    url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.json',
+    crossOrigin: 'anonymous'
+  }),
+  minResolution: 4000,
+  maxResolution: 10000
+});
+
+var imageWMSLayer = new ol.layer.Image({
+  extent: [-13884991, 2870341, -7455066, 6338219],
+  source: new ol.source.ImageWMS({
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    params: {'LAYERS': 'topp:states', 'TILED': true},
+    serverType: 'geoserver'
+  }),
+  minResolution: 4000,
+  maxResolution: 10000
+});
+
+var vectorSource = new ol.source.Vector();
+var markers = [];
+
+for (var i = 0; i < 50; i++) {
+  var x = Math.floor((Math.random() * -18000000));
+  var y =  Math.floor((Math.random() * 10000000));
+  var marker = new ol.Feature(new ol.geom.Point([x, y]));
+  marker.setStyle(new ol.style.Style({
+      image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+        anchor: [0.5, 46],
+        anchorXUnits: 'fraction',
+        anchorYUnits: 'pixels',
+        src: 'data/icon.png'
+      }))
+    })
+  );
+  markers.push(marker);
+}
+
+vectorSource.addFeatures(markers);
+var vectorLayer = new ol.layer.Vector({
+  source: vectorSource,
+  minResolution: 4000,
+  maxResolution: 10000
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    tileJSONLayer,
+    imageWMSLayer,
+    vectorLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+
+function toggleOSM() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -45,6 +45,12 @@ olgm.herald.Feature = function(ol3map, gmap, options) {
    */
   this.mapIconOptions_ = options.mapIconOptions;
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.visible_ = options.visible !== undefined ? options.visible : true;
+
   goog.base(this, ol3map, gmap);
 
 };
@@ -85,7 +91,10 @@ olgm.herald.Feature.prototype.activate = function() {
 
   // create gmap feature
   this.gmapFeature_ = olgm.gm.createFeature(this.feature_);
-  this.data_.add(this.gmapFeature_);
+
+  if (this.visible_) {
+    this.data_.add(this.gmapFeature_);
+  }
 
   // override style if a style is defined at the feature level
   var gmStyle = olgm.gm.createStyle(
@@ -107,13 +116,17 @@ olgm.herald.Feature.prototype.activate = function() {
         this.mapIconOptions_.useCanvas : false;
     if (image && image instanceof ol.style.Icon && useCanvas) {
       this.marker_ = olgm.gm.createMapIcon(image, latLng, index);
-      this.marker_.setMap(this.gmap);
+      if (this.visible_) {
+        this.marker_.setMap(this.gmap);
+      }
     }
 
     var text = style.getText();
     if (text) {
       this.label_ = olgm.gm.createLabel(text, latLng, index);
-      this.label_.setMap(this.gmap);
+      if (this.visible_) {
+        this.label_.setMap(this.gmap);
+      }
     }
   }
 
@@ -152,6 +165,40 @@ olgm.herald.Feature.prototype.deactivate = function() {
   }
 
   goog.base(this, 'deactivate');
+};
+
+
+/**
+ * Set visible or invisible, without deleting the feature object
+ * @param {boolean} value true to set visible, false to set invisible
+ */
+olgm.herald.Feature.prototype.setVisible = function(value) {
+  if (value && !this.visible_) {
+    this.data_.add(this.gmapFeature_);
+
+    if (this.marker_) {
+      this.marker_.setMap(this.gmap);
+    }
+
+    if (this.label_) {
+      this.label_.setMap(this.gmap);
+    }
+
+    this.visible_ = true;
+  } else if (!value && this.visible_) {
+
+    this.data_.remove(this.gmapFeature_);
+
+    if (this.marker_) {
+      this.marker_.setMap(null);
+    }
+
+    if (this.label_) {
+      this.label_.setMap(null);
+    }
+
+    this.visible_ = false;
+  }
 };
 
 

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -232,6 +232,15 @@ olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(cacheItem) {
   var layer = cacheItem.layer;
   var url = this.generateImageWMSFunction_(layer);
 
+  // Check if we're within the accepted resolutions
+  var minResolution = layer.getMinResolution();
+  var maxResolution = layer.getMaxResolution();
+  var currentResolution = this.ol3map.getView().getResolution();
+  if (currentResolution < minResolution || currentResolution > maxResolution) {
+    this.resetImageOverlay_(cacheItem);
+    return;
+  }
+
   /* We listen to both change:resolution and moveend events. However, changing
    * resolution eventually sends a moveend event as well. Using only the
    * moveend event makes zooming in/out look bad. To prevent rendering the

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -93,6 +93,15 @@ olgm.herald.TileSource.prototype.googleGetTileUrlFunction_ = function(
   var source = tileLayer.getSource();
   goog.asserts.assertInstanceof(source, ol.source.TileImage);
 
+  // Check if we're within the accepted resolutions
+  var minResolution = tileLayer.getMinResolution();
+  var maxResolution = tileLayer.getMaxResolution();
+  var currentResolution = this.ol3map.getView().getResolution();
+  if (currentResolution < minResolution || currentResolution > maxResolution) {
+    return;
+  }
+
+
   // Get a few variables from the source object
   var getTileUrlFunction = source.getTileUrlFunction();
   var proj = ol.proj.get('EPSG:3857');

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -52,6 +52,12 @@ olgm.herald.VectorFeature = function(
    */
   this.mapIconOptions_ = mapIconOptions;
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.visible_ = true;
+
   goog.base(this, ol3map, gmap);
 };
 goog.inherits(olgm.herald.VectorFeature, olgm.herald.Herald);
@@ -81,6 +87,18 @@ olgm.herald.VectorFeature.prototype.deactivate = function() {
   this.source_.getFeatures().forEach(this.unwatchFeature_, this);
 
   goog.base(this, 'deactivate');
+};
+
+
+/**
+ * Set each feature visible or invisible
+ * @param {boolean} value true for visible, false for invisible
+ */
+olgm.herald.VectorFeature.prototype.setVisible = function(value) {
+  this.visible_ = value;
+  for (var i = 0; i < this.cache_.length; i++) {
+    this.cache_[i].herald.setVisible(value);
+  }
 };
 
 
@@ -126,7 +144,8 @@ olgm.herald.VectorFeature.prototype.watchFeature_ = function(feature) {
     feature: feature,
     data: data,
     index: index,
-    mapIconOptions: this.mapIconOptions_
+    mapIconOptions: this.mapIconOptions_,
+    visible: this.visible_
   };
   var herald = new olgm.herald.Feature(ol3map, gmap, options);
   herald.activate();

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -81,6 +81,11 @@ olgm.herald.VectorSource.prototype.watchLayer = function(layer) {
   cacheItem.listenerKeys.push(vectorLayer.on('change:visible',
       this.handleVisibleChange_.bind(this, cacheItem), this));
 
+  var view = this.ol3map.getView();
+  cacheItem.listenerKeys.push(view.on('change:resolution',
+      this.handleResolutionChange_.bind(this, cacheItem), this));
+
+
   this.activateCacheItem_(cacheItem);
 
   this.cache_.push(cacheItem);
@@ -164,6 +169,21 @@ olgm.herald.VectorSource.prototype.deactivateCacheItem_ = function(
     cacheItem) {
   cacheItem.herald.deactivate();
   cacheItem.layer.setOpacity(cacheItem.opacity);
+};
+
+
+olgm.herald.VectorSource.prototype.handleResolutionChange_ = function(
+    cacheItem) {
+  var layer = cacheItem.layer;
+
+  var minResolution = layer.getMinResolution();
+  var maxResolution = layer.getMaxResolution();
+  var currentResolution = this.ol3map.getView().getResolution();
+  if (currentResolution < minResolution || currentResolution > maxResolution) {
+    cacheItem.herald.setVisible(false);
+  } else {
+    cacheItem.herald.setVisible(true);
+  }
 };
 
 


### PR DESCRIPTION
This fix adds support for layer attributes minResolution and maxResolution. Here's how it works:

On imageWMS and tile layer heralds, we already have a function to generate the tiles to render in Google Maps. With this fix, we check if we're within the mininum and maximum resolution before creating those tiles. If we're not, we simply return, so no requests are made.

On vector layers, we listen to the resolution change event (when we zoom in and out). Each time it happens, we check if we're within the minimum and maximum resolutions for that layer. We tell the result to the vectorFeatureHerald, which in turn gives the result to every feature it possess. When a feature is set invisible, we remove it from the Google Maps map, without deleting the feature itself. When we set it visible, we put it back on the back.
