### PR TITLE
Add options to watch image and tile layers

### DIFF
--- a/examples/watchoptions.html
+++ b/examples/watchoptions.html
@@ -49,6 +49,12 @@
             it will eliminate any limitation of the library for that type of
             layer.
           </p>
+          <p>
+            In this example, you can enable and disable watching different
+            types of layers with the buttons below. When it's green, it means
+            Google Maps is allowed to render it when a Google Layer is visible.
+            When it's red, OpenLayers renders that layer type at all times.
+          </p>
 
           <table>
             <tr>

--- a/examples/watchoptions.html
+++ b/examples/watchoptions.html
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps watch options example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="../css/ol3gm.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+    <style>
+      table button {
+        width: 100%;
+      }
+      table {
+        margin: 5px;
+      }
+      td {
+        border-color: #555;
+        border-style: solid;
+        border-width: 3px;
+      }
+      td.inactive {
+        background-color: #ffaaaa;
+      }
+      td.active {
+        background-color: #aaffaa;
+      }
+    </style>
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Watch options example</h4>
+          <p>
+            Demonstrates the watch options
+          </p>
+          <p>
+            You can choose to let OL3 render the layers over the Google Maps
+            basemap. It will cause a visible lag when panning or zooming, but
+            it will eliminate any limitation of the library for that type of
+            layer.
+          </p>
+
+          <table>
+            <tr>
+              <td colspan=3>
+                <button id="toggle" type="button" onclick="toggle();">
+                  Toggle Between OL3 and GMAPS
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td class="inactive" id="image">
+                <button type="button" onclick="toggleWatch('image')">
+                  Toggle watch image layers
+                </button>
+              </td>
+              <td class="inactive" id="tile">
+                <button type="button" onclick="toggleWatch('tile')">
+                  Toggle watch tile layers
+                </button>
+              </td>
+              <td class="inactive" id="vector">
+                <button type="button" onclick="toggleWatch('vector')">
+                  Toggle watch vector layers
+                </button>
+              </td>
+            </tr>
+          </table>
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3&key=mykey
+         where mykey is your Google Maps API key -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3"></script>
+
+    <script src="/@loader"></script>
+    <script src="watchoptions.js"></script>
+  </body>
+</html>

--- a/examples/watchoptions.js
+++ b/examples/watchoptions.js
@@ -1,0 +1,95 @@
+var center = [-10997148, 4569099];
+
+var googleLayer = new olgm.layer.Google();
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+
+var imageWMSLayer = new ol.layer.Image({
+  source: new ol.source.ImageWMS({
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    params: {'LAYERS': 'topp:states', 'TILED': true},
+    serverType: 'geoserver'
+  })
+})
+
+var tileWMSLayer  =  new ol.layer.Tile({
+  source: new ol.source.TileWMS({
+    url: 'http://wms.ess-ws.nrcan.gc.ca/wms/toporama_en',
+    params: {'LAYERS': 'limits', 'TILED': true},
+    serverType: 'geoserver'
+  })
+});
+
+var source = new ol.source.Vector();
+
+var watchOptions = {
+  'image': false,
+  'tile': false,
+  'vector': false
+};
+
+// Add some randomly generated markers
+var markers = [];
+
+for (var i = 0; i < 10; i++) {
+  var x = Math.floor((Math.random() * 1000000) - 10997148);
+  var y =  Math.floor((Math.random() * 1000000) + 4569099);
+  var marker = new ol.Feature(new ol.geom.Point([x, y]));
+  marker.setStyle(new ol.style.Style({
+      image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+        anchor: [0.5, 46],
+        anchorXUnits: 'fraction',
+        anchorYUnits: 'pixels',
+        src: 'data/icon.png'
+      })),
+      zIndex: i
+    })
+  );
+  markers.push(marker);
+}
+
+source.addFeatures(markers);
+
+var vector = new ol.layer.Vector({
+  source: source
+});
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    osmLayer,
+    tileWMSLayer,
+    imageWMSLayer,
+    googleLayer,
+    vector
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({
+  map: map,
+  watchOptions: watchOptions
+}); // map is the ol.Map instance
+olGM.activate();
+
+
+function toggle() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+};
+
+function toggleWatch(option) {
+  watchOptions[option] = !watchOptions[option];
+  var cell = document.getElementById(option);
+  var className = watchOptions[option] == true ? 'active' : 'inactive';
+  cell.className = className;
+  olGM.setWatchOptions(watchOptions);
+};

--- a/examples/watchoptions.js
+++ b/examples/watchoptions.js
@@ -76,7 +76,7 @@ var map = new ol.Map({
 
 var olGM = new olgm.OLGoogleMaps({
   map: map,
-  watchOptions: watchOptions
+  watch: watchOptions
 }); // map is the ol.Map instance
 olGM.activate();
 

--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -10,7 +10,7 @@ var olgmx;
  * @typedef {{
  *   map: (!ol.Map),
  *   mapIconOptions: (olgmx.gm.MapIconOptions|undefined),
- *   watchOptions: (olgmx.herald.WatchOptions|undefined)
+ *   watch: (olgmx.herald.WatchOptions|undefined)
  * }}
  * @api
  */
@@ -40,7 +40,7 @@ olgmx.OLGoogleMapsOptions.prototype.mapIconOptions;
  * @type {olgmx.herald.WatchOptions|undefined}
  * @api
  */
-olgmx.OLGoogleMapsOptions.prototype.watchOptions;
+olgmx.OLGoogleMapsOptions.prototype.watch;
 
 
 /**
@@ -94,6 +94,30 @@ olgmx.herald.FeatureOptions;
  * @api
  */
 olgmx.herald.WatchOptions;
+
+
+/**
+ * Whether to watch image layers or not
+ * @type {boolean|undefined}
+ * @api
+ */
+olgmx.herald.WatchOptions.prototype.image;
+
+
+/**
+ * Whether to watch tiled layers or not
+ * @type {boolean|undefined}
+ * @api
+ */
+olgmx.herald.WatchOptions.prototype.tile;
+
+
+/**
+ * Whether to watch vector layers or not
+ * @type {boolean|undefined}
+ * @api
+ */
+olgmx.herald.WatchOptions.prototype.vector;
 
 
 /**

--- a/externs/olgmx.js
+++ b/externs/olgmx.js
@@ -10,7 +10,7 @@ var olgmx;
  * @typedef {{
  *   map: (!ol.Map),
  *   mapIconOptions: (olgmx.gm.MapIconOptions|undefined),
- *   watchVector: (boolean|undefined)
+ *   watchOptions: (olgmx.herald.WatchOptions|undefined)
  * }}
  * @api
  */
@@ -34,12 +34,13 @@ olgmx.OLGoogleMapsOptions.prototype.mapIconOptions;
 
 
 /**
- * Whether the library should watch vector layers and let them be rendered
- * by Google Maps with the latter is activated or not.  Defaults to `true`.
- * @type {boolean|undefined}
+ * For each layer type, a boolean indicating whether the library should watch
+ * and let layers of that type them be rendered by Google Maps or not.
+ * Defaults to `true` for each option.
+ * @type {olgmx.herald.WatchOptions|undefined}
  * @api
  */
-olgmx.OLGoogleMapsOptions.prototype.watchVector;
+olgmx.OLGoogleMapsOptions.prototype.watchOptions;
 
 
 /**
@@ -82,6 +83,17 @@ olgmx.herald = {};
  * @api
  */
 olgmx.herald.FeatureOptions;
+
+
+/**
+ * @typedef {{
+ *   image: (boolean|undefined),
+ *   tile: (boolean|undefined),
+ *   vector: (boolean|undefined)
+ * }}
+ * @api
+ */
+olgmx.herald.WatchOptions;
 
 
 /**

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -61,8 +61,8 @@ olgm.OLGoogleMaps = function(options) {
 
   goog.base(this, options.map, gmap);
 
-  var watchOptions = options.watchOptions !== undefined ?
-      options.watchOptions : {};
+  var watchOptions = options.watch !== undefined ?
+      options.watch : {};
 
   var mapIconOptions = options.mapIconOptions !== undefined ?
       options.mapIconOptions : {};

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -61,8 +61,8 @@ olgm.OLGoogleMaps = function(options) {
 
   goog.base(this, options.map, gmap);
 
-  var watchVector = options.watchVector !== undefined ?
-      options.watchVector : true;
+  var watchOptions = options.watchOptions !== undefined ?
+      options.watchOptions : {};
 
   var mapIconOptions = options.mapIconOptions !== undefined ?
       options.mapIconOptions : {};
@@ -72,7 +72,7 @@ olgm.OLGoogleMaps = function(options) {
    * @private
    */
   this.layersHerald_ = new olgm.herald.Layers(
-      this.ol3map, this.gmap, watchVector, mapIconOptions);
+      this.ol3map, this.gmap, mapIconOptions, watchOptions);
   this.heralds_.push(this.layersHerald_);
 };
 goog.inherits(olgm.OLGoogleMaps, olgm.Abstract);
@@ -136,6 +136,18 @@ olgm.OLGoogleMaps.prototype.getGoogleMapsActive = function() {
  */
 olgm.OLGoogleMaps.prototype.getGoogleMapsMap = function() {
   return this.gmap;
+};
+
+
+/**
+ * Set the watch options
+ * @param {olgmx.herald.WatchOptions} watchOptions whether each layer type
+ * should be watched
+ * @api
+ */
+olgm.OLGoogleMaps.prototype.setWatchOptions = function(watchOptions) {
+  var newWatchOptions = watchOptions !== undefined ? watchOptions : {};
+  this.layersHerald_.setWatchOptions(newWatchOptions);
 };
 
 


### PR DESCRIPTION
This PR fixes issue #94 by changing the watchVector option to a watchOptions object, containing a property for each layer type. It also adds a function to change the watchOptions on an already existing olGM object. 

It also includes an example, so it fixes issue #68, although it does not contain the cool features mentioned in that issue.
