### PR TITLE
Support layer order for tile and image layers

### DIFF
--- a/examples/order.html
+++ b/examples/order.html
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>OL3-Google-Maps order example</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css" />
+    <link rel="stylesheet" href="./resources/layout.css" type="text/css" />
+    <style>
+      #layerTree {
+        border: solid black 2px;
+        margin: 5px;
+        width: 512px;
+      }
+      #layerTree div {
+        position: relative;
+        border: solid black 1px;
+        padding: 8px;
+      }
+      #layerTree button.up {
+        position: absolute;
+        right: 50px;
+      }
+      #layerTree button.down {
+        position: absolute;
+        right: 10px;
+      }
+    </style>
+  </head>
+  <body>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+      <div class="row-fluid">
+        <div class="span12">
+          <h4>Order example</h4>
+          <table>
+            <tr>
+              <td>
+                <input id="toggle" type="button" onclick="toggle();"
+                       value="Toggle between OL3 and GMAPS" />
+
+                <div id="layerTree">
+              </td>
+              <td>
+                <p>
+                  In this example, layers are displayed in the table on the
+                  left. They can be re-ordered by clicking the arrow buttons
+                  next to their names. The top-most layers will display in
+                  front of the layers placed below them in the table. The base
+                  Google layer is not affected by this, it will always display
+                  behind every layer. Vector layers will also always display in
+                  front of every layer while Google Maps is active.
+                </p>
+              </td>
+            </tr>
+          </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="../node_modules/openlayers/build/ol.js"></script>
+
+    <!-- When loading Google Maps outside of localhost, replace the src with
+         https://maps.googleapis.com/maps/api/js?v=3&key=mykey
+         where mykey is your Google Maps API key -->
+    <script type="text/javascript"
+            src="https://maps.googleapis.com/maps/api/js?v=3"></script>
+
+    <script src="/@loader"></script>
+    <script src="order.js"></script>
+  </body>
+</html>

--- a/examples/order.js
+++ b/examples/order.js
@@ -1,13 +1,15 @@
 var center = [-10997148, 6569099];
 
 var googleLayer = new olgm.layer.Google();
-googleLayer.name = "Google layer - Base layer";
+googleLayer.name = 'Google layer - Base layer';
+googleLayer.color = 'rgb(163, 204, 255)'
 
 var osmLayer = new ol.layer.Tile({
   source: new ol.source.OSM(),
   visible: false
 });
-osmLayer.name = "OSM layer - Base layer";
+osmLayer.name = 'OSM layer - Base layer';
+osmLayer.color = 'rgb(241, 238, 232)';
 
 var tileWMSLayer  =  new ol.layer.Tile({
   source: new ol.source.TileWMS({
@@ -17,7 +19,8 @@ var tileWMSLayer  =  new ol.layer.Tile({
   }),
   visible: true,
 });
-tileWMSLayer.name = "Tile WMS - Canadian provinces";
+tileWMSLayer.name = 'Tile WMS - Canadian provinces';
+tileWMSLayer.color = 'rgb(255, 251, 200)';
 
 var imageWMSLayer = new ol.layer.Image({
   source: new ol.source.ImageWMS({
@@ -27,7 +30,8 @@ var imageWMSLayer = new ol.layer.Image({
   }),
   visible: true,
 });
-imageWMSLayer.name = "Image WMS - Red/Green/Blue USA";
+imageWMSLayer.name = 'Image WMS - Red/Green/Blue USA';
+imageWMSLayer.color = 'rgb(126, 241, 109)';
 
 var imageWMSLayer2  =  new ol.layer.Image({
   extent: [-16884991, 2870341, -3455066, 12338219],
@@ -37,7 +41,8 @@ var imageWMSLayer2  =  new ol.layer.Image({
   }),
   visible: true,
 });
-imageWMSLayer2.name = "Image WMS - Canadian boundaries";
+imageWMSLayer2.name = 'Image WMS - Canadian boundaries';
+imageWMSLayer2.color = '#aaaaaa';
 
 // Setup tilegrid for wmts layer
 var projection = ol.proj.get('EPSG:3857');
@@ -72,7 +77,8 @@ var wmtsLayer = new ol.layer.Tile({
     wrapX: true
   }),
 });
-wmtsLayer.name = "Tile WMTS - Orange USA"
+wmtsLayer.name = 'Tile WMTS - Orange USA'
+wmtsLayer.color = 'rgb(241, 207, 185)';
 
 var map = new ol.Map({
   // use OL3-Google-Maps recommended default interactions
@@ -105,7 +111,8 @@ function createLayerTree() {
     var layer = layers.getArray()[i];
 
     var item = document.createElement('div');
-    var moreText = layer.getVisible() ? "" : "(invisible) ";
+    item.style.backgroundColor = layer.color;
+    var moreText = layer.getVisible() ? '' : '(invisible) ';
     var itemText = document.createTextNode(moreText + layer.name);
 
     item.appendChild(itemText);

--- a/examples/order.js
+++ b/examples/order.js
@@ -1,0 +1,161 @@
+var center = [-10997148, 6569099];
+
+var googleLayer = new olgm.layer.Google();
+googleLayer.name = "Google layer - Base layer";
+
+var osmLayer = new ol.layer.Tile({
+  source: new ol.source.OSM(),
+  visible: false
+});
+osmLayer.name = "OSM layer - Base layer";
+
+var tileWMSLayer  =  new ol.layer.Tile({
+  source: new ol.source.TileWMS({
+    url: 'http://wms.ess-ws.nrcan.gc.ca/wms/toporama_en',
+    params: {'LAYERS': 'limits', 'TILED': true},
+    serverType: 'geoserver'
+  }),
+  visible: true,
+});
+tileWMSLayer.name = "Tile WMS - Canadian provinces";
+
+var imageWMSLayer = new ol.layer.Image({
+  source: new ol.source.ImageWMS({
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
+    params: {'LAYERS': 'topp:states', 'TILED': true},
+    serverType: 'geoserver'
+  }),
+  visible: true,
+});
+imageWMSLayer.name = "Image WMS - Red/Green/Blue USA";
+
+var imageWMSLayer2  =  new ol.layer.Image({
+  extent: [-16884991, 2870341, -3455066, 12338219],
+  source: new ol.source.ImageWMS({
+    url: 'http://wms.ess-ws.nrcan.gc.ca/wms/toporama_en',
+    params: {'LAYERS': 'boundaries'}
+  }),
+  visible: true,
+});
+imageWMSLayer2.name = "Image WMS - Canadian boundaries";
+
+// Setup tilegrid for wmts layer
+var projection = ol.proj.get('EPSG:3857');
+var projectionExtent = projection.getExtent();
+var size = ol.extent.getWidth(projectionExtent) / 256;
+var resolutions = new Array(14);
+var matrixIds = new Array(14);
+for (var z = 0; z < 14; ++z) {
+  // generate resolutions and matrixIds arrays for this WMTS
+  resolutions[z] = size / Math.pow(2, z);
+  matrixIds[z] = z;
+}
+
+var wmtsLayer = new ol.layer.Tile({
+  opacity: 0.7,
+  source: new ol.source.WMTS({
+    attributions: '' +
+        'Tiles © <a href="http://services.arcgisonline.com/arcgis/rest/' +
+        'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>',
+    url: 'http://services.arcgisonline.com/arcgis/rest/' +
+        'services/Demographics/USA_Population_Density/MapServer/WMTS/',
+    layer: '0',
+    matrixSet: 'EPSG:3857',
+    format: 'image/png',
+    projection: projection,
+    tileGrid: new ol.tilegrid.WMTS({
+      origin: ol.extent.getTopLeft(projectionExtent),
+      resolutions: resolutions,
+      matrixIds: matrixIds
+    }),
+    style: 'default',
+    wrapX: true
+  }),
+});
+wmtsLayer.name = "Tile WMTS - Orange USA"
+
+var map = new ol.Map({
+  // use OL3-Google-Maps recommended default interactions
+  interactions: olgm.interaction.defaults(),
+  layers: [
+    googleLayer,
+    osmLayer,
+    imageWMSLayer,
+    imageWMSLayer2,
+    tileWMSLayer,
+    wmtsLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: center,
+    zoom: 4
+  })
+});
+
+var olGM = new olgm.OLGoogleMaps({map: map}); // map is the ol.Map instance
+olGM.activate();
+createLayerTree();
+
+function createLayerTree() {
+  var layerTreeElement = document.getElementById('layerTree');
+  layerTreeElement.innerHTML = '';
+  var layers = map.getLayers();
+
+  for (var i = layers.getLength() - 1; i >= 0; i--) {
+    var layer = layers.getArray()[i];
+
+    var item = document.createElement('div');
+    var moreText = layer.getVisible() ? "" : "(invisible) ";
+    var itemText = document.createTextNode(moreText + layer.name);
+
+    item.appendChild(itemText);
+
+    if (i != layers.getLength() - 1) {
+      var upButton = document.createElement('button');
+      upButton.className = 'up';
+      upButton.onclick = moveUp.bind(upButton, layer)
+      var upButtonText = document.createTextNode('\u25B2');
+      upButton.appendChild(upButtonText);
+      item.appendChild(upButton);
+    }
+
+    if (i != 0) {
+      var downButton = document.createElement('button');
+      downButton.className = 'down';
+      downButton.onclick = moveDown.bind(downButton, layer);
+      var downButtonText = document.createTextNode('\u25BC');
+      downButton.appendChild(downButtonText);
+      item.appendChild(downButton);
+    }
+
+    layerTreeElement.appendChild(item);
+  }
+}
+
+function moveUp(layer) {
+  var layers = map.getLayers();
+  var index = layers.getArray().indexOf(layer);
+
+  layers.removeAt(index);
+  layers.insertAt(index + 1, layer);
+
+  createLayerTree();
+}
+
+function moveDown(layer) {
+  var layers = map.getLayers();
+  var index = layers.getArray().indexOf(layer);
+
+  layers.removeAt(index);
+  layers.insertAt(index - 1, layer);
+
+  createLayerTree();
+}
+
+
+
+function toggle() {
+  googleLayer.setVisible(!googleLayer.getVisible());
+  osmLayer.setVisible(!osmLayer.getVisible());
+  createLayerTree();
+};

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -34,6 +34,12 @@ olgm.gm.ImageOverlay = function(src, size, topLeft) {
    * @private
    */
   this.div_ = null;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.zIndex_ = 0;
 };
 if (window.google && window.google.maps) {
   goog.inherits(olgm.gm.ImageOverlay, google.maps.OverlayView);
@@ -49,6 +55,7 @@ olgm.gm.ImageOverlay.prototype.onAdd = function() {
   div.style.borderStyle = 'none';
   div.style.borderWidth = '0px';
   div.style.position = 'absolute';
+  div.style.zIndex = this.zIndex_;
 
   // Create the img element and attach it to the div.
   var img = document.createElement('img');
@@ -60,9 +67,13 @@ olgm.gm.ImageOverlay.prototype.onAdd = function() {
 
   this.div_ = div;
 
-  // Add the element to the "overlayLayer" pane.
+  /**
+   * Add the element to the "mapPane" pane. Normally we would put it in the
+   * "overlayLayer" pane, but we want to be able to show it behind tile layers,
+   * so we place them together in the same pane.
+   */
   var panes = this.getPanes();
-  panes.overlayLayer.appendChild(div);
+  panes.mapPane.appendChild(div);
 };
 
 
@@ -99,6 +110,19 @@ olgm.gm.ImageOverlay.prototype.draw = function() {
 
   div.style.top = offsetY + 'px';
   div.style.left = offsetX + 'px';
+};
+
+
+/**
+ * Set the zIndex for the div containing the image
+ * @param {number} zIndex zIndex to set
+ * @api
+ */
+olgm.gm.ImageOverlay.prototype.setZIndex = function(zIndex) {
+  this.zIndex_ = zIndex;
+  if (this.div_) {
+    this.div_.style.zIndex = zIndex;
+  }
 };
 
 

--- a/src/gm/panesoverlay.js
+++ b/src/gm/panesoverlay.js
@@ -1,0 +1,54 @@
+goog.provide('olgm.gm.PanesOverlay');
+
+
+/**
+ * This overlay doesn't actually do anything, it's only a way to get the map's
+ * panes since Google Maps' API doesn't offer any other way to do so.
+ * @param {google.maps.Map} gmap Google Maps map
+ * @constructor
+ * @extends {google.maps.OverlayView}
+ * @api
+ */
+olgm.gm.PanesOverlay = function(gmap) {
+  this.setMap(gmap);
+};
+if (window.google && window.google.maps) {
+  goog.inherits(olgm.gm.PanesOverlay, google.maps.OverlayView);
+}
+
+
+/**
+ * This function is the only reason this class exists. It returns the panes.
+ * @return {google.maps.MapPanes|undefined} array of panes
+ * @api
+ */
+olgm.gm.PanesOverlay.prototype.getMapPanes = function() {
+  return this.getPanes();
+};
+
+
+/**
+ * Override parent function, but do not do anything
+ * @api
+ */
+olgm.gm.PanesOverlay.prototype.onAdd = function() {
+
+};
+
+
+/**
+ * Override parent function, but do not do anything
+ * @api
+ */
+olgm.gm.PanesOverlay.prototype.draw = function() {
+
+};
+
+
+/**
+ * Override parent function, but do not do anything
+ * @api
+ */
+olgm.gm.PanesOverlay.prototype.onRemove = function() {
+
+};

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -52,7 +52,8 @@ olgm.herald.ImageWMSSource.prototype.watchLayer = function(layer) {
     lastUrl: null,
     layer: imageLayer,
     listenerKeys: [],
-    opacity: opacity
+    opacity: opacity,
+    zIndex: 0
   });
 
   // Hide the google layer when the ol3 layer is invisible
@@ -280,6 +281,7 @@ olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(cacheItem) {
       url,
       size,
       topLeftLatLng);
+  overlay.setZIndex(cacheItem.zIndex);
 
   // Set the new overlay right away to give it time to render
   overlay.setMap(this.gmap);
@@ -289,6 +291,26 @@ olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(cacheItem) {
 
   // Save new overlay
   cacheItem.imageOverlay = overlay;
+};
+
+
+/**
+ * Order the layers by index in the ol3 layers array
+ * @api
+ */
+olgm.herald.ImageWMSSource.prototype.orderLayers = function() {
+  for (var i = 0; i < this.cache_.length; i++) {
+    var cacheItem = this.cache_[i];
+
+    // There won't be an imageOverlay while Google Maps isn't visible
+    if (cacheItem.imageOverlay) {
+      var layer = cacheItem.layer;
+      var zIndex = this.findIndex(layer);
+
+      cacheItem.imageOverlay.setZIndex(zIndex);
+      cacheItem.zIndex = zIndex;
+    }
+  }
 };
 
 
@@ -340,7 +362,8 @@ olgm.herald.ImageWMSSource.prototype.handleMoveEnd_ = function(
  *   lastUrl: (string|null),
  *   layer: (ol.layer.Image),
  *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
- *   opacity: (number)
+ *   opacity: (number),
+ *   zIndex: (number)
  * }}
  */
 olgm.herald.ImageWMSSource.LayerCache;

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -230,6 +230,7 @@ olgm.herald.Layers.prototype.handleLayersAdd_ = function(event) {
   var layer = event.element;
   goog.asserts.assertInstanceof(layer, ol.layer.Base);
   this.watchLayer_(layer);
+  this.orderLayers();
 };
 
 
@@ -242,6 +243,7 @@ olgm.herald.Layers.prototype.handleLayersRemove_ = function(event) {
   var layer = event.element;
   goog.asserts.assertInstanceof(layer, ol.layer.Base);
   this.unwatchLayer_(layer);
+  this.orderLayers();
 };
 
 
@@ -363,6 +365,8 @@ olgm.herald.Layers.prototype.activateGoogleMaps_ = function() {
   this.imageWMSSourceHerald_.activate();
   this.tileSourceHerald_.activate();
   this.vectorSourceHerald_.activate();
+
+  this.orderLayers();
 };
 
 
@@ -438,6 +442,16 @@ olgm.herald.Layers.prototype.toggleGoogleMaps_ = function() {
     // deactivate
     this.deactivateGoogleMaps_();
   }
+};
+
+
+/**
+ * Order the layers for each herald that supports it
+ * @api
+ */
+olgm.herald.Layers.prototype.orderLayers = function() {
+  this.imageWMSSourceHerald_.orderLayers();
+  this.tileSourceHerald_.orderLayers();
 };
 
 

--- a/src/herald/sourceherald.js
+++ b/src/herald/sourceherald.js
@@ -53,3 +53,22 @@ olgm.herald.Source.prototype.unwatchLayer = goog.abstractMethod;
 olgm.herald.Source.prototype.setGoogleMapsActive = function(active) {
   this.googleMapsIsActive = active;
 };
+
+
+/**
+ * Find the index of a layer in the ol3 map's layers
+ * @param {ol.layer.Base} layer layer to find in ol3's layers array
+ * @returns {number} suggested zIndex for that layer
+ * @api
+ */
+olgm.herald.Source.prototype.findIndex = function(layer) {
+  var layers = this.ol3map.getLayers().getArray();
+  var layerIndex = layers.indexOf(layer);
+  var zIndex = layer.getZIndex();
+
+  if (zIndex != 0) {
+    layerIndex = zIndex;
+  }
+
+  return layerIndex;
+};

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -164,6 +164,18 @@ olgm.OLGoogleMaps.prototype.toggle = function() {
 
 
 /**
+ * Trigger the layer ordering functions in the heralds. We listen for layers
+ * added and removed, which usually happens when we change the order of the
+ * layers in OL3, but this function allows refreshing it manually in case
+ * the order is being change in another way.
+ * @api
+ */
+olgm.OLGoogleMaps.prototype.orderLayers = function() {
+  this.layersHerald_.orderLayers();
+};
+
+
+/**
  * Refresh layers and features that might need it (only ImageWMS so far)
  * @api
  */


### PR DESCRIPTION
This commit has the objective of ordering the layers the same way OpenLayer does.

Google Maps has several "panes" where it render things. Layers in one pane will always display above layers in the next one, no matter what. The first thing I had to do was to make sure the image and tile layers were in the same pane. The simpliest way to achieve that was to move the image layers to the mapPane pane, where tiled layers are rendered.

The next step was finding a way to make them display in the right order. To do that, we could either place them in the correct order in the mapPane, or set a zIndex on each of them. I chose the second solution.

For the image layers, it's pretty simple since we create the div. When we do, we set the zIndex if we can, otherwise we leave it at 0. There is a function to set the zIndex on the div later if we need to.

For tile layers, it's a little more complicated. Google Maps doesn't give us any way to access the divs where tiles are rendered. First, we need to access the pane element. The only way to do so is from objects inheriting google.maps.OverlayView. I created a PanesOverlay object, which doesn't do anything other than provide a way to access the mapPane. This object is instanciated in the tileSourceHerald. It can only access the pane once Google Maps is done loading, which means we can't set the zIndex on tile layers as we add them on the map, unless we delay their creation. I decided to not delay it and set the zIndex later instead. 

Once Google Maps is "idle", or whenever a layer is added or removed, we call the orderLayers function in the tileSourceHerald. In this function, we loop through every tile layer we're watching, and for each of them, we remove them and add them back in Google Maps. This provides us a way to guess which div they are rendered in. Then, we set a timeout to change the zIndex for that div, as Google Maps likes to set it back to 0 if we don't...

The example included is a good way to test it. The map rendered by OL3 and Google Maps should always be identical, other than the OSM and Google Maps layers.
