### PR TITLE
Update Openlayers to version 3.17.1

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -188,6 +188,7 @@ function build(config, paths, callback) {
     concatenate(paths, callback);
   } else {
     log.info('ol3-google-maps', 'Compiling ' + paths.length + ' sources');
+    paths = paths.concat('node_modules/openlayers/src/ol/typedefs.js');
     options.compile.js = paths.concat(options.compile.js || []);
     closure.compile(options, callback);
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsdoc": "~3.4.0",
     "mocha": "2.5.3",
     "mocha-phantomjs-core": "^1.3.1",
-    "openlayers": "3.16.0",
+    "openlayers": "3.17.1",
     "phantomjs-prebuilt": "2.1.7",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -116,7 +116,7 @@ olgm.gm.createGeometry = function(geometry, opt_ol3map) {
 
 /**
  * Create a Google Maps data style options from an OpenLayers object.
- * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature}
+ * @param {ol.style.Style|ol.StyleFunction|ol.layer.Vector|ol.Feature}
  * object style object
  * @param {olgmx.gm.MapIconOptions} mapIconOptions map icon options
  * @param {number=} opt_index index for the object

--- a/src/herald/herald.js
+++ b/src/herald/herald.js
@@ -17,7 +17,7 @@ goog.require('olgm.Abstract');
 olgm.herald.Herald = function(ol3map, gmap) {
 
   /**
-   * @type {Array.<ol.events.Key|Array.<ol.events.Key>>}
+   * @type {Array.<ol.EventsKey|Array.<ol.EventsKey>>}
    * @protected
    */
   this.listenerKeys = [];

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -361,7 +361,7 @@ olgm.herald.ImageWMSSource.prototype.handleMoveEnd_ = function(
  *   imageOverlay: (olgm.gm.ImageOverlay),
  *   lastUrl: (string|null),
  *   layer: (ol.layer.Image),
- *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   listenerKeys: (Array.<ol.EventsKey|Array.<ol.EventsKey>>),
  *   opacity: (number),
  *   zIndex: (number)
  * }}

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -467,7 +467,7 @@ olgm.herald.Layers.prototype.refresh = function() {
 /**
  * @typedef {{
  *   layer: (olgm.layer.Google),
- *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>)
+ *   listenerKeys: (Array.<ol.EventsKey|Array.<ol.EventsKey>>)
  * }}
  */
 olgm.herald.Layers.GoogleLayerCache;

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -422,7 +422,7 @@ olgm.herald.TileSource.prototype.handleVisibleChange_ = function(cacheItem) {
  *   googleTileLayer: (google.maps.ImageMapType),
  *   ignoreNextOpacityChange: (boolean),
  *   layer: (ol.layer.Tile),
- *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   listenerKeys: (Array.<ol.EventsKey|Array.<ol.EventsKey>>),
  *   opacity: (number),
  *   zIndex: (number)
  * }}

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -210,7 +210,7 @@ olgm.herald.VectorSource.prototype.handleVisibleChange_ = function(
  *   data: (google.maps.Data),
  *   herald: (olgm.herald.VectorFeature),
  *   layer: (ol.layer.Vector),
- *   listenerKeys: (Array.<ol.events.Key|Array.<ol.events.Key>>),
+ *   listenerKeys: (Array.<ol.EventsKey|Array.<ol.EventsKey>>),
  *   opacity: (number)
  * }}
  */

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -113,7 +113,7 @@ olgm.getColorOpacity = function(color) {
 
 /**
  * Get the style from the specified object.
- * @param {ol.style.Style|ol.style.StyleFunction|ol.layer.Vector|ol.Feature}
+ * @param {ol.style.Style|ol.StyleFunction|ol.layer.Vector|ol.Feature}
  object object from which we get the style
  * @return {?ol.style.Style} the style of the object
  */
@@ -191,7 +191,7 @@ olgm.stringStartsWith = function(string, needle) {
 
 
 /**
- * @param {Array.<ol.events.Key|Array.<ol.events.Key>>} listenerKeys listener
+ * @param {Array.<ol.EventsKey|Array.<ol.EventsKey>>} listenerKeys listener
  * keys
  * @param {Array.<goog.events.Key>=} opt_googListenerKeys closure listener keys
  */


### PR DESCRIPTION
This PR updates OpenLayers to version 3.17.1. Some typedefs have been renamed, and an additional instruction has been added in build.js.
