### PR TITLE
Remove use of goog.base

### DIFF
--- a/build/ol3gm.json
+++ b/build/ol3gm.json
@@ -30,7 +30,6 @@
       "*"
     ],
     "jscomp_off": [
-      "useOfGoogBase",
       "lintChecks",
       "analyzerChecks"
     ],

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -1,5 +1,8 @@
 goog.provide('olgm.gm.ImageOverlay');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
+
 
 /**
  * Creates a new image overlay.
@@ -42,7 +45,7 @@ olgm.gm.ImageOverlay = function(src, size, topLeft) {
   this.zIndex_ = 0;
 };
 if (window.google && window.google.maps) {
-  goog.inherits(olgm.gm.ImageOverlay, google.maps.OverlayView);
+  ol.inherits(olgm.gm.ImageOverlay, google.maps.OverlayView);
 }
 
 

--- a/src/gm/mapelement.js
+++ b/src/gm/mapelement.js
@@ -1,5 +1,9 @@
 goog.provide('olgm.gm.MapElement');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
+
+
 /**
  * This class is a parent for all elements that are drawn manually onto Google
  * Maps. This means drawing elements on a canvas attached to the Google Maps
@@ -21,7 +25,7 @@ olgm.gm.MapElement = function() {
 
 };
 if (window.google && window.google.maps) {
-  goog.inherits(olgm.gm.MapElement, google.maps.OverlayView);
+  ol.inherits(olgm.gm.MapElement, google.maps.OverlayView);
 }
 
 

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.gm.MapIcon');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.gm.MapElement');
 
 
@@ -12,7 +14,8 @@ goog.require('olgm.gm.MapElement');
  * @api
  */
 olgm.gm.MapIcon = function(imageStyle, opt_options) {
-  goog.base(this);
+
+  olgm.gm.MapElement.call(this);
 
   /**
    * This object contains the ol3 style properties for the icon. We keep
@@ -25,7 +28,7 @@ olgm.gm.MapIcon = function(imageStyle, opt_options) {
 
   this.setValues(opt_options);
 };
-goog.inherits(olgm.gm.MapIcon, olgm.gm.MapElement);
+ol.inherits(olgm.gm.MapIcon, olgm.gm.MapElement);
 
 
 /**

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -33,6 +33,8 @@
 
 goog.provide('olgm.gm.MapLabel');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.gm.MapElement');
 
 
@@ -44,7 +46,8 @@ goog.require('olgm.gm.MapElement');
  * @api
  */
 olgm.gm.MapLabel = function(opt_options) {
-  goog.base(this);
+
+  olgm.gm.MapElement.call(this);
 
   this.set('font', 'normal 10px sans-serif');
   this.set('textAlign', 'center');
@@ -54,7 +57,7 @@ olgm.gm.MapLabel = function(opt_options) {
 
   this.setValues(opt_options);
 };
-goog.inherits(olgm.gm.MapLabel, olgm.gm.MapElement);
+ol.inherits(olgm.gm.MapLabel, olgm.gm.MapElement);
 
 
 /**

--- a/src/gm/panesoverlay.js
+++ b/src/gm/panesoverlay.js
@@ -1,5 +1,8 @@
 goog.provide('olgm.gm.PanesOverlay');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
+
 
 /**
  * This overlay doesn't actually do anything, it's only a way to get the map's
@@ -13,7 +16,7 @@ olgm.gm.PanesOverlay = function(gmap) {
   this.setMap(gmap);
 };
 if (window.google && window.google.maps) {
-  goog.inherits(olgm.gm.PanesOverlay, google.maps.OverlayView);
+  ol.inherits(olgm.gm.PanesOverlay, google.maps.OverlayView);
 }
 
 

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -1,6 +1,8 @@
 goog.provide('olgm.herald.Feature');
 
 goog.require('goog.asserts');
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm');
 goog.require('olgm.gm');
 goog.require('olgm.herald.Herald');
@@ -51,10 +53,10 @@ olgm.herald.Feature = function(ol3map, gmap, options) {
    */
   this.visible_ = options.visible !== undefined ? options.visible : true;
 
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Herald.call(this, ol3map, gmap);
 
 };
-goog.inherits(olgm.herald.Feature, olgm.herald.Herald);
+ol.inherits(olgm.herald.Feature, olgm.herald.Herald);
 
 
 /**
@@ -84,7 +86,8 @@ olgm.herald.Feature.prototype.marker_ = null;
  * @inheritDoc
  */
 olgm.herald.Feature.prototype.activate = function() {
-  goog.base(this, 'activate');
+
+  olgm.herald.Herald.prototype.activate.call(this);
 
   var geometry = this.feature_.getGeometry();
   goog.asserts.assertInstanceof(geometry, ol.geom.Geometry);
@@ -164,7 +167,7 @@ olgm.herald.Feature.prototype.deactivate = function() {
     this.label_ = null;
   }
 
-  goog.base(this, 'deactivate');
+  olgm.herald.Herald.prototype.deactivate.call(this);
 };
 
 

--- a/src/herald/herald.js
+++ b/src/herald/herald.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.herald.Herald');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm');
 goog.require('olgm.Abstract');
 
@@ -28,9 +30,9 @@ olgm.herald.Herald = function(ol3map, gmap) {
    */
   this.googListenerKeys = [];
 
-  goog.base(this, ol3map, gmap);
+  olgm.Abstract.call(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.Herald, olgm.Abstract);
+ol.inherits(olgm.herald.Herald, olgm.Abstract);
 
 
 /**

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.herald.ImageWMSSource');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.gm.ImageOverlay');
 goog.require('olgm.herald.Source');
 
@@ -24,9 +26,9 @@ olgm.herald.ImageWMSSource = function(ol3map, gmap) {
   */
   this.layers_ = [];
 
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Source.call(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.ImageWMSSource, olgm.herald.Source);
+ol.inherits(olgm.herald.ImageWMSSource, olgm.herald.Source);
 
 
 /**
@@ -102,7 +104,7 @@ olgm.herald.ImageWMSSource.prototype.unwatchLayer = function(layer) {
  * @override
  */
 olgm.herald.ImageWMSSource.prototype.activate = function() {
-  olgm.herald.ImageWMSSource.base(this, 'activate'); // Call parent function
+  olgm.herald.Source.prototype.activate.call(this);
   this.cache_.forEach(this.activateCacheItem_, this);
 };
 
@@ -130,7 +132,7 @@ olgm.herald.ImageWMSSource.prototype.activateCacheItem_ = function(
  * @override
  */
 olgm.herald.ImageWMSSource.prototype.deactivate = function() {
-  olgm.herald.ImageWMSSource.base(this, 'deactivate'); //Call parent function
+  olgm.herald.Source.prototype.deactivate.call(this);
   this.cache_.forEach(this.deactivateCacheItem_, this);
 };
 

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -115,7 +115,7 @@ olgm.herald.Layers = function(ol3map, gmap, mapIconOptions, watchOptions) {
   this.targetEl_ = ol3map.getTargetElement();
 
 
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Herald.call(this, ol3map, gmap);
 
 
   // some controls, like the ol.control.ZoomSlider, require the map div
@@ -137,7 +137,7 @@ olgm.herald.Layers = function(ol3map, gmap, mapIconOptions, watchOptions) {
     }, this);
   }
 };
-goog.inherits(olgm.herald.Layers, olgm.herald.Herald);
+ol.inherits(olgm.herald.Layers, olgm.herald.Herald);
 
 
 /**
@@ -160,7 +160,8 @@ olgm.herald.Layers.prototype.ol3mapIsRenderered_ = false;
  * @inheritDoc
  */
 olgm.herald.Layers.prototype.activate = function() {
-  goog.base(this, 'activate');
+
+  olgm.herald.Herald.prototype.activate.call(this);
 
   var layers = this.ol3map.getLayers();
 
@@ -181,7 +182,7 @@ olgm.herald.Layers.prototype.deactivate = function() {
   // unwatch existing layers
   this.ol3map.getLayers().forEach(this.unwatchLayer_, this);
 
-  goog.base(this, 'deactivate');
+  olgm.herald.Herald.prototype.deactivate.call(this);
 };
 
 

--- a/src/herald/sourceherald.js
+++ b/src/herald/sourceherald.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.herald.Source');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.herald.Herald');
 
 
@@ -13,7 +15,8 @@ goog.require('olgm.herald.Herald');
  * @extends {olgm.herald.Herald}
  */
 olgm.herald.Source = function(ol3map, gmap) {
-  goog.base(this, ol3map, gmap);
+
+  olgm.herald.Herald.call(this, ol3map, gmap);
 
   /**
    * Flag that determines whether the GoogleMaps map is currently active, i.e.
@@ -23,7 +26,7 @@ olgm.herald.Source = function(ol3map, gmap) {
    */
   olgm.herald.Source.prototype.googleMapsIsActive_ = false;
 };
-goog.inherits(olgm.herald.Source, olgm.herald.Herald);
+ol.inherits(olgm.herald.Source, olgm.herald.Herald);
 
 
 /**

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.herald.TileSource');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.gm.PanesOverlay');
 goog.require('olgm.herald.Source');
 
@@ -40,9 +42,9 @@ olgm.herald.TileSource = function(ol3map, gmap) {
     this.orderLayers();
   }, this));
 
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Source.call(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.TileSource, olgm.herald.Source);
+ol.inherits(olgm.herald.TileSource, olgm.herald.Source);
 
 
 /**
@@ -256,7 +258,7 @@ olgm.herald.TileSource.prototype.unwatchLayer = function(layer) {
  * @api
  */
 olgm.herald.TileSource.prototype.activate = function() {
-  olgm.herald.TileSource.base(this, 'activate'); // Call parent function
+  olgm.herald.Source.prototype.activate.call(this);
   this.cache_.forEach(this.activateCacheItem_, this);
 };
 
@@ -282,7 +284,7 @@ olgm.herald.TileSource.prototype.activateCacheItem_ = function(
  * @api
  */
 olgm.herald.TileSource.prototype.deactivate = function() {
-  olgm.herald.TileSource.base(this, 'deactivate'); //Call parent function
+  olgm.herald.Source.prototype.deactivate.call(this);
   this.cache_.forEach(this.deactivateCacheItem_, this);
 };
 

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -1,6 +1,8 @@
 goog.provide('olgm.herald.VectorFeature');
 
 goog.require('goog.asserts');
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.herald.Feature');
 goog.require('olgm.herald.Herald');
 
@@ -58,16 +60,17 @@ olgm.herald.VectorFeature = function(
    */
   this.visible_ = true;
 
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Herald.call(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.VectorFeature, olgm.herald.Herald);
+ol.inherits(olgm.herald.VectorFeature, olgm.herald.Herald);
 
 
 /**
  * @inheritDoc
  */
 olgm.herald.VectorFeature.prototype.activate = function() {
-  goog.base(this, 'activate');
+
+  olgm.herald.Herald.prototype.activate.call(this);
 
   // watch existing features...
   this.source_.getFeatures().forEach(this.watchFeature_, this);
@@ -86,7 +89,7 @@ olgm.herald.VectorFeature.prototype.deactivate = function() {
   // unwatch existing features...
   this.source_.getFeatures().forEach(this.unwatchFeature_, this);
 
-  goog.base(this, 'deactivate');
+  olgm.herald.Herald.prototype.deactivate.call(this);
 };
 
 

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -1,5 +1,7 @@
 goog.provide('olgm.herald.VectorSource');
 
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm.herald.Source');
 goog.require('olgm.herald.VectorFeature');
 
@@ -31,9 +33,9 @@ olgm.herald.VectorSource = function(ol3map, gmap, mapIconOptions) {
    */
   this.mapIconOptions_ = mapIconOptions;
 
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Source.call(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.VectorSource, olgm.herald.Source);
+ol.inherits(olgm.herald.VectorSource, olgm.herald.Source);
 
 
 /**
@@ -128,7 +130,7 @@ olgm.herald.VectorSource.prototype.unwatchLayer = function(layer) {
  * @api
  */
 olgm.herald.VectorSource.prototype.activate = function() {
-  olgm.herald.VectorSource.base(this, 'activate'); // Call parent function
+  olgm.herald.Source.prototype.activate.call(this);
   this.cache_.forEach(this.activateCacheItem_, this);
 };
 
@@ -154,7 +156,7 @@ olgm.herald.VectorSource.prototype.activateCacheItem_ = function(
  * @api
  */
 olgm.herald.VectorSource.prototype.deactivate = function() {
-  olgm.herald.VectorSource.base(this, 'deactivate'); //Call parent function
+  olgm.herald.Source.prototype.deactivate.call(this);
   this.cache_.forEach(this.deactivateCacheItem_, this);
 };
 

--- a/src/herald/viewherald.js
+++ b/src/herald/viewherald.js
@@ -3,6 +3,8 @@ goog.provide('olgm.herald.View');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+/** @suppress {extraRequire} */
+goog.require('ol.has');
 goog.require('olgm');
 goog.require('olgm.herald.Herald');
 
@@ -20,9 +22,9 @@ goog.require('olgm.herald.Herald');
  * @extends {olgm.herald.Herald}
  */
 olgm.herald.View = function(ol3map, gmap) {
-  goog.base(this, ol3map, gmap);
+  olgm.herald.Herald.call(this, ol3map, gmap);
 };
-goog.inherits(olgm.herald.View, olgm.herald.Herald);
+ol.inherits(olgm.herald.View, olgm.herald.Herald);
 
 
 /**
@@ -38,7 +40,8 @@ olgm.herald.View.prototype.windowResizeTimerId_ = null;
  * @inheritDoc
  */
 olgm.herald.View.prototype.activate = function() {
-  goog.base(this, 'activate');
+
+  olgm.herald.Herald.prototype.activate.call(this);
 
   var view = this.ol3map.getView();
   var keys = this.listenerKeys;
@@ -73,7 +76,7 @@ olgm.herald.View.prototype.activate = function() {
  * @inheritDoc
  */
 olgm.herald.View.prototype.deactivate = function() {
-  goog.base(this, 'deactivate');
+  olgm.herald.Herald.prototype.deactivate.call(this);
 };
 
 

--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -17,7 +17,7 @@ olgm.layer.Google = function(opt_options) {
 
   var options = opt_options !== undefined ? opt_options : {};
 
-  goog.base(this, /** @type {olx.layer.GroupOptions} */ (options));
+  ol.layer.Group.call(this, /** @type {olx.layer.GroupOptions} */ (options));
 
   /**
    * @type {google.maps.MapTypeId.<(number|string)>|string}
@@ -33,7 +33,7 @@ olgm.layer.Google = function(opt_options) {
   this.styles_ = options.styles ? options.styles : null;
 
 };
-goog.inherits(olgm.layer.Google, ol.layer.Group);
+ol.inherits(olgm.layer.Google, ol.layer.Group);
 
 
 /**

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -59,7 +59,7 @@ olgm.OLGoogleMaps = function(options) {
     streetViewControl: false
   });
 
-  goog.base(this, options.map, gmap);
+  olgm.Abstract.call(this, options.map, gmap);
 
   var watchOptions = options.watch !== undefined ?
       options.watch : {};
@@ -75,7 +75,7 @@ olgm.OLGoogleMaps = function(options) {
       this.ol3map, this.gmap, mapIconOptions, watchOptions);
   this.heralds_.push(this.layersHerald_);
 };
-goog.inherits(olgm.OLGoogleMaps, olgm.Abstract);
+ol.inherits(olgm.OLGoogleMaps, olgm.Abstract);
 
 
 /**


### PR DESCRIPTION
Also, use `ol.inherits` instead of `goog.inherits`. Normally, that
would require to add `goog.require('ol')`, but for an unknown reason
this throws a dependency error. Using `goog.require('ol.has')` works,
so we use that instead.
