### PR TITLE
Fix default anchor in map icon

### DIFF
--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -73,7 +73,7 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
   var ctx = canvas.getContext('2d');
   ctx.clearRect(0,0,canvas.width, canvas.height);
 
-  var anchor = this.imageStyle_.getAnchor();
+  var anchor = this.imageStyle_.getAnchor() || [0, 0];
   var scale = this.imageStyle_.getScale() || 1;
   var rotation = this.imageStyle_.getRotation() || 0;
   var opacity = this.imageStyle_.getOpacity() || 1;


### PR DESCRIPTION
In some occasions, an error gets thrown when loading any of the examples that use the minized version. The culprit seems to be what's been fixed in this PR.

@samuellapointe Would you please review ?
