### PR TITLE
Support custom params changes from WMS sources

### DIFF
--- a/examples/wms.html
+++ b/examples/wms.html
@@ -29,6 +29,8 @@
                  value="Toggle between OL3 and GMAPS" />
           <input id="toggleWMS" type="button" onclick="toggleWMS();"
                  value="Toggle between tiled WMS and image WMS" />
+         <input id="setRandomParam" type="button" onclick="setRandomParam();"
+                 value="Set a random param to all layer sources" />
           <span>Current mode: </span>
           <span id="currentMode">tiled</span>
         </div>

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -81,3 +81,13 @@ function toggleWMS() {
   var spanText = tileWMSLayer.getVisible() ? 'tiled' : 'image';
   document.getElementById('currentMode').innerHTML = spanText;
 }
+
+function setRandomParam() {
+  var params = {
+    'random': Math.random()
+  };
+  tileWMSLayer.getSource().updateParams(params);
+  tileWMSLayer2.getSource().updateParams(params);
+  imageWMSLayer.getSource().updateParams(params);
+  imageWMSLayer2.getSource().updateParams(params);
+};

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -203,7 +203,9 @@ olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
   for (key in params) {
     var upperCaseKey = key.toUpperCase();
     if (wmsParamsList.indexOf(upperCaseKey) === -1) {
-      customParams[key] = params[key];
+      if (params[key] !== undefined && params[key] !== null) {
+        customParams[key] = params[key];
+      }
     } else {
       wmsParams[upperCaseKey] = params[key];
     }

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -68,6 +68,11 @@ olgm.herald.ImageWMSSource.prototype.watchLayer = function(layer) {
   cacheItem.listenerKeys.push(this.ol3map.getView().on('change:resolution',
       this.handleMoveEnd_.bind(this, cacheItem), this));
 
+  // Make sure that any change to the layer source itself also updates the
+  // google maps layer
+  cacheItem.listenerKeys.push(imageLayer.getSource().on('change',
+      this.handleMoveEnd_.bind(this, cacheItem), this));
+
   // Activate the cache item
   this.activateCacheItem_(cacheItem);
   this.cache_.push(cacheItem);
@@ -161,6 +166,7 @@ olgm.herald.ImageWMSSource.prototype.deactivateCacheItem_ = function(
  */
 olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
     layer) {
+  var key;
   var source = layer.getSource();
   goog.asserts.assertInstanceof(source, ol.source.ImageWMS);
 
@@ -176,21 +182,41 @@ olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
   var view = ol3map.getView();
   var bbox = view.calculateExtent(size);
 
-  // Set all keys in params to uppercase
-  for (var key in params) {
+  // Separate original WMS params and custom ones
+  var wmsParamsList = [
+    'CRS',
+    'BBOX',
+    'FORMAT',
+    'HEIGHT',
+    'LAYERS',
+    'REQUEST',
+    'SERVICE',
+    'SRS',
+    'STYLES',
+    'TILED',
+    'TRANSPARENT',
+    'VERSION',
+    'WIDTH'
+  ];
+  var customParams = {};
+  var wmsParams = {};
+  for (key in params) {
     var upperCaseKey = key.toUpperCase();
-    if (key != upperCaseKey && !params[upperCaseKey]) {
-      params[upperCaseKey] = params[key];
+    if (wmsParamsList.indexOf(upperCaseKey) === -1) {
+      customParams[key] = params[key];
+    } else {
+      wmsParams[upperCaseKey] = params[key];
     }
   }
 
-  // Get params
-  var version = params['VERSION'] ? params['VERSION'] : '1.3.0';
-  var layers = params['LAYERS'] ? params['LAYERS'] : '';
-  var styles = params['STYLES'] ? params['STYLES'] : '';
-  var format = params['FORMAT'] ? params['FORMAT'] : 'image/png';
-  var transparent = params['TRANSPARENT'] ? params['TRANSPARENT'] : 'TRUE';
-  var tiled = params['TILED'] ? params['TILED'] : 'FALSE';
+  // Set WMS params
+  var version = wmsParams['VERSION'] ? wmsParams['VERSION'] : '1.3.0';
+  var layers = wmsParams['LAYERS'] ? wmsParams['LAYERS'] : '';
+  var styles = wmsParams['STYLES'] ? wmsParams['STYLES'] : '';
+  var format = wmsParams['FORMAT'] ? wmsParams['FORMAT'] : 'image/png';
+  var transparent = wmsParams['TRANSPARENT'] ?
+      wmsParams['TRANSPARENT'] : 'TRUE';
+  var tiled = wmsParams['TILED'] ? wmsParams['TILED'] : 'FALSE';
 
   // Check whether or not we're using WMS 1.3.0
   var versionNumbers = version.split('.');
@@ -211,6 +237,11 @@ olgm.herald.ImageWMSSource.prototype.generateImageWMSFunction_ = function(
   url += '&WIDTH=' + size[0];
   url += '&HEIGHT=' + size[1];
   url += '&TILED=' + tiled;
+
+  // Set Custom params
+  for (key in customParams) {
+    url += '&' + key + '=' + customParams[key];
+  }
 
   return url;
 };

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -106,6 +106,8 @@ olgm.herald.TileSource.prototype.watchLayer = function(layer) {
       this.handleVisibleChange_.bind(this, cacheItem), this));
   cacheItem.listenerKeys.push(tileLayer.on('change:opacity',
       this.handleOpacityChange_.bind(this, cacheItem), this));
+  cacheItem.listenerKeys.push(tileLayer.getSource().on('change',
+      this.handleSourceChange_.bind(this, cacheItem), this));
 
   // Activate the cache item
   this.activateCacheItem_(cacheItem);
@@ -415,6 +417,21 @@ olgm.herald.TileSource.prototype.handleVisibleChange_ = function(cacheItem) {
     }
     this.deactivateCacheItem_(cacheItem);
   }
+};
+
+
+/**
+ * Called the source of layer fires the 'change' event. Reload the google tile
+ * layer.
+ *
+ * @param {olgm.herald.TileSource.LayerCache} cacheItem cacheItem for the
+ * watched layer
+ * @private
+ */
+olgm.herald.TileSource.prototype.handleSourceChange_ = function(cacheItem) {
+  // Note: The 'changed' method of google.maps.MVCObject requires a param,
+  //       but it's not acutally used here.  It's just to satisfy the compiler.
+  cacheItem.googleTileLayer.changed('foo');
 };
 
 


### PR DESCRIPTION
When we were adding a layer that had a TileWMS source, if one of the inner parameters changed (for example, a custom parameter), ol3-google-maps was not detecting this change and the tiles it generated didn't include the updated param.  This patch fixes this issue.

When we were adding a layer that had a ImageWMS source, none of the custom inner parameters were supported.  The WMS GetMap request was only using the WMS parameters.  This patch makes sure that any custom parameters are also read and given to the google maps layer.  It also makes sure to listen to any change to the source itself to reload the google layer accordingly too.

This patch also adds a button in the WMS example to test this new feature.
