### PR TITLE
Fix zIndex of ImageWMS layer

### DIFF
--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -345,14 +345,13 @@ olgm.herald.ImageWMSSource.prototype.updateImageOverlay_ = function(
 olgm.herald.ImageWMSSource.prototype.orderLayers = function() {
   for (var i = 0; i < this.cache_.length; i++) {
     var cacheItem = this.cache_[i];
+    var layer = cacheItem.layer;
+    var zIndex = this.findIndex(layer);
+    cacheItem.zIndex = zIndex;
 
     // There won't be an imageOverlay while Google Maps isn't visible
     if (cacheItem.imageOverlay) {
-      var layer = cacheItem.layer;
-      var zIndex = this.findIndex(layer);
-
       cacheItem.imageOverlay.setZIndex(zIndex);
-      cacheItem.zIndex = zIndex;
     }
   }
 };


### PR DESCRIPTION
This patch fixes the assignment of the zIndex of the ImageWMS layers.  Without the patch, if a layer had for example a 'minResolution' or 'maxResolution' set upon initialization, the cacheItem didn't have the `imageOverlay` set yet, so the zIndex was not saved in the cache and thereafter, when the visibility of the layer got on and the overlay created, the zIndex wasn't set so we ended up with layers in the incorrect order.

This patch fixes this.