### PR TITLE
Upgrade Google Maps API extern file to v3.26

### DIFF
--- a/build/ol3gm.json
+++ b/build/ol3gm.json
@@ -19,7 +19,7 @@
       "node_modules/openlayers/externs/geojson.js",
       "node_modules/openlayers/externs/bingmaps.js",
       "node_modules/openlayers/externs/closure-compiler.js",
-      "externs/google_maps_api_v3_24.js"
+      "externs/google_maps_api_v3_26.js"
     ],
     "define": [
       "goog.DEBUG=false"

--- a/externs/google_maps_api_v3_26.js
+++ b/externs/google_maps_api_v3_26.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @fileoverview Externs for the Google Maps v3.24 API.
+ * @fileoverview Externs for the Google Maps v3.26 API.
  * @see http://code.google.com/apis/maps/documentation/javascript/reference.html
  * @externs
  */
@@ -38,7 +38,7 @@ google.maps.Animation = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.Attribution = function() {};
 
@@ -167,7 +167,7 @@ google.maps.Circle.prototype.setRadius = function(radius) {};
 google.maps.Circle.prototype.setVisible = function(visible) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.CircleOptions = function() {};
 
@@ -267,10 +267,10 @@ google.maps.ControlPosition = {
 google.maps.Data = function(opt_options) {};
 
 /**
- * @param {google.maps.Data.Feature|google.maps.Data.FeatureOptions|Object.<string>} feature
+ * @param {(google.maps.Data.Feature|google.maps.Data.FeatureOptions|Object.<string>)=} opt_feature
  * @return {google.maps.Data.Feature}
  */
-google.maps.Data.prototype.add = function(feature) {};
+google.maps.Data.prototype.add = function(opt_feature) {};
 
 /**
  * @param {Object} geoJson
@@ -391,7 +391,7 @@ google.maps.Data.prototype.setStyle = function(style) {};
 google.maps.Data.prototype.toGeoJson = function(callback) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.AddFeatureEvent = function() {};
 
@@ -401,27 +401,27 @@ google.maps.Data.AddFeatureEvent = function() {};
 google.maps.Data.AddFeatureEvent.prototype.feature;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.DataOptions = function() {};
 
 /**
- * @type {google.maps.ControlPosition}
+ * @type {google.maps.ControlPosition|undefined}
  */
 google.maps.Data.DataOptions.prototype.controlPosition;
 
 /**
- * @type {Array<string>}
+ * @type {Array<string>|undefined}
  */
 google.maps.Data.DataOptions.prototype.controls;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Data.DataOptions.prototype.drawingMode;
 
 /**
- * @type {function(google.maps.Data.Geometry): google.maps.Data.Feature}
+ * @type {(function(google.maps.Data.Geometry): google.maps.Data.Feature)|undefined}
  */
 google.maps.Data.DataOptions.prototype.featureFactory;
 
@@ -431,7 +431,7 @@ google.maps.Data.DataOptions.prototype.featureFactory;
 google.maps.Data.DataOptions.prototype.map;
 
 /**
- * @type {google.maps.Data.StylingFunction|google.maps.Data.StyleOptions|Object.<string>}
+ * @type {google.maps.Data.StylingFunction|google.maps.Data.StyleOptions|Object.<string>|undefined}
  */
 google.maps.Data.DataOptions.prototype.style;
 
@@ -491,27 +491,27 @@ google.maps.Data.Feature.prototype.setProperty = function(name, newValue) {};
 google.maps.Data.Feature.prototype.toGeoJson = function(callback) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.FeatureOptions = function() {};
 
 /**
- * @type {google.maps.Data.Geometry|google.maps.LatLng|google.maps.LatLngLiteral}
+ * @type {google.maps.Data.Geometry|google.maps.LatLng|google.maps.LatLngLiteral|undefined}
  */
 google.maps.Data.FeatureOptions.prototype.geometry;
 
 /**
- * @type {number|string}
+ * @type {number|string|undefined}
  */
 google.maps.Data.FeatureOptions.prototype.id;
 
 /**
- * @type {Object}
+ * @type {Object|undefined}
  */
 google.maps.Data.FeatureOptions.prototype.properties;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.GeoJsonOptions = function() {};
 
@@ -526,6 +526,12 @@ google.maps.Data.GeoJsonOptions.prototype.idPropertyName;
 google.maps.Data.Geometry = function() {};
 
 /**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ */
+google.maps.Data.Geometry.prototype.forEachLatLng = function(callback) {};
+
+/**
  * @nosideeffects
  * @return {string}
  */
@@ -537,6 +543,13 @@ google.maps.Data.Geometry.prototype.getType = function() {};
  * @constructor
  */
 google.maps.Data.GeometryCollection = function(elements) {};
+
+/**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.GeometryCollection.prototype.forEachLatLng = function(callback) {};
 
 /**
  * @nosideeffects
@@ -571,6 +584,13 @@ google.maps.Data.GeometryCollection.prototype.getType = function() {};
 google.maps.Data.LineString = function(elements) {};
 
 /**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.LineString.prototype.forEachLatLng = function(callback) {};
+
+/**
  * @nosideeffects
  * @return {Array<google.maps.LatLng>}
  */
@@ -601,6 +621,13 @@ google.maps.Data.LineString.prototype.getType = function() {};
  * @constructor
  */
 google.maps.Data.LinearRing = function(elements) {};
+
+/**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.LinearRing.prototype.forEachLatLng = function(callback) {};
 
 /**
  * @nosideeffects
@@ -646,6 +673,13 @@ google.maps.Data.MouseEvent.prototype.feature;
 google.maps.Data.MultiLineString = function(elements) {};
 
 /**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.MultiLineString.prototype.forEachLatLng = function(callback) {};
+
+/**
  * @nosideeffects
  * @return {Array<google.maps.Data.LineString>}
  */
@@ -676,6 +710,13 @@ google.maps.Data.MultiLineString.prototype.getType = function() {};
  * @constructor
  */
 google.maps.Data.MultiPoint = function(elements) {};
+
+/**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.MultiPoint.prototype.forEachLatLng = function(callback) {};
 
 /**
  * @nosideeffects
@@ -710,6 +751,13 @@ google.maps.Data.MultiPoint.prototype.getType = function() {};
 google.maps.Data.MultiPolygon = function(elements) {};
 
 /**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.MultiPolygon.prototype.forEachLatLng = function(callback) {};
+
+/**
  * @nosideeffects
  * @return {Array<google.maps.Data.Polygon>}
  */
@@ -742,6 +790,13 @@ google.maps.Data.MultiPolygon.prototype.getType = function() {};
 google.maps.Data.Point = function(latLng) {};
 
 /**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.Point.prototype.forEachLatLng = function(callback) {};
+
+/**
  * @nosideeffects
  * @return {google.maps.LatLng}
  */
@@ -760,6 +815,13 @@ google.maps.Data.Point.prototype.getType = function() {};
  * @constructor
  */
 google.maps.Data.Polygon = function(elements) {};
+
+/**
+ * @param {function(google.maps.LatLng)} callback
+ * @return {undefined}
+ * @override
+ */
+google.maps.Data.Polygon.prototype.forEachLatLng = function(callback) {};
 
 /**
  * @nosideeffects
@@ -787,7 +849,7 @@ google.maps.Data.Polygon.prototype.getLength = function() {};
 google.maps.Data.Polygon.prototype.getType = function() {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.RemoveFeatureEvent = function() {};
 
@@ -797,7 +859,7 @@ google.maps.Data.RemoveFeatureEvent = function() {};
 google.maps.Data.RemoveFeatureEvent.prototype.feature;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.RemovePropertyEvent = function() {};
 
@@ -817,7 +879,7 @@ google.maps.Data.RemovePropertyEvent.prototype.name;
 google.maps.Data.RemovePropertyEvent.prototype.oldValue;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.SetGeometryEvent = function() {};
 
@@ -827,17 +889,17 @@ google.maps.Data.SetGeometryEvent = function() {};
 google.maps.Data.SetGeometryEvent.prototype.feature;
 
 /**
- * @type {google.maps.Data.Geometry}
+ * @type {google.maps.Data.Geometry|undefined}
  */
 google.maps.Data.SetGeometryEvent.prototype.newGeometry;
 
 /**
- * @type {google.maps.Data.Geometry}
+ * @type {google.maps.Data.Geometry|undefined}
  */
 google.maps.Data.SetGeometryEvent.prototype.oldGeometry;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.SetPropertyEvent = function() {};
 
@@ -862,77 +924,77 @@ google.maps.Data.SetPropertyEvent.prototype.newValue;
 google.maps.Data.SetPropertyEvent.prototype.oldValue;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Data.StyleOptions = function() {};
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.Data.StyleOptions.prototype.clickable;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Data.StyleOptions.prototype.cursor;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.Data.StyleOptions.prototype.draggable;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.Data.StyleOptions.prototype.editable;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Data.StyleOptions.prototype.fillColor;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.Data.StyleOptions.prototype.fillOpacity;
 
 /**
- * @type {string|google.maps.Icon|google.maps.Symbol}
+ * @type {string|google.maps.Icon|google.maps.Symbol|undefined}
  */
 google.maps.Data.StyleOptions.prototype.icon;
 
 /**
- * @type {google.maps.MarkerShape}
+ * @type {google.maps.MarkerShape|undefined}
  */
 google.maps.Data.StyleOptions.prototype.shape;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Data.StyleOptions.prototype.strokeColor;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.Data.StyleOptions.prototype.strokeOpacity;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.Data.StyleOptions.prototype.strokeWeight;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Data.StyleOptions.prototype.title;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.Data.StyleOptions.prototype.visible;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.Data.StyleOptions.prototype.zIndex;
 
@@ -942,7 +1004,7 @@ google.maps.Data.StyleOptions.prototype.zIndex;
 google.maps.Data.StylingFunction;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsGeocodedWaypoint = function() {};
 
@@ -962,7 +1024,7 @@ google.maps.DirectionsGeocodedWaypoint.prototype.place_id;
 google.maps.DirectionsGeocodedWaypoint.prototype.types;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsLeg = function() {};
 
@@ -1083,7 +1145,7 @@ google.maps.DirectionsRenderer.prototype.setPanel = function(panel) {};
 google.maps.DirectionsRenderer.prototype.setRouteIndex = function(routeIndex) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsRendererOptions = function() {};
 
@@ -1158,57 +1220,57 @@ google.maps.DirectionsRendererOptions.prototype.suppressMarkers;
 google.maps.DirectionsRendererOptions.prototype.suppressPolylines;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsRequest = function() {};
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DirectionsRequest.prototype.avoidFerries;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DirectionsRequest.prototype.avoidHighways;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DirectionsRequest.prototype.avoidTolls;
 
 /**
- * @type {string|google.maps.LatLng|google.maps.Place}
+ * @type {string|google.maps.LatLng|google.maps.Place|google.maps.LatLngLiteral}
  */
 google.maps.DirectionsRequest.prototype.destination;
 
 /**
- * @type {google.maps.DrivingOptions|Object.<string>}
+ * @type {google.maps.DrivingOptions|Object.<string>|undefined}
  */
 google.maps.DirectionsRequest.prototype.drivingOptions;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DirectionsRequest.prototype.optimizeWaypoints;
 
 /**
- * @type {string|google.maps.LatLng|google.maps.Place}
+ * @type {string|google.maps.LatLng|google.maps.Place|google.maps.LatLngLiteral}
  */
 google.maps.DirectionsRequest.prototype.origin;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DirectionsRequest.prototype.provideRouteAlternatives;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.DirectionsRequest.prototype.region;
 
 /**
- * @type {google.maps.TransitOptions|Object.<string>}
+ * @type {google.maps.TransitOptions|Object.<string>|undefined}
  */
 google.maps.DirectionsRequest.prototype.transitOptions;
 
@@ -1218,17 +1280,17 @@ google.maps.DirectionsRequest.prototype.transitOptions;
 google.maps.DirectionsRequest.prototype.travelMode;
 
 /**
- * @type {google.maps.UnitSystem}
+ * @type {google.maps.UnitSystem|undefined}
  */
 google.maps.DirectionsRequest.prototype.unitSystem;
 
 /**
- * @type {Array<google.maps.DirectionsWaypoint>}
+ * @type {Array<google.maps.DirectionsWaypoint>|undefined}
  */
 google.maps.DirectionsRequest.prototype.waypoints;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsResult = function() {};
 
@@ -1243,7 +1305,7 @@ google.maps.DirectionsResult.prototype.geocoded_waypoints;
 google.maps.DirectionsResult.prototype.routes;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsRoute = function() {};
 
@@ -1314,7 +1376,7 @@ google.maps.DirectionsStatus = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsStep = function() {};
 
@@ -1364,22 +1426,22 @@ google.maps.DirectionsStep.prototype.transit;
 google.maps.DirectionsStep.prototype.travel_mode;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DirectionsWaypoint = function() {};
 
 /**
- * @type {string|google.maps.LatLng|google.maps.Place}
+ * @type {string|google.maps.LatLng|google.maps.Place|undefined}
  */
 google.maps.DirectionsWaypoint.prototype.location;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DirectionsWaypoint.prototype.stopover;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Distance = function() {};
 
@@ -1403,47 +1465,47 @@ google.maps.DistanceMatrixElementStatus = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.DistanceMatrixRequest = function() {};
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.avoidFerries;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.avoidHighways;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.avoidTolls;
 
 /**
- * @type {Array<string|google.maps.LatLng|google.maps.Place>}
+ * @type {Array<(string|google.maps.LatLng|google.maps.Place)>}
  */
 google.maps.DistanceMatrixRequest.prototype.destinations;
 
 /**
- * @type {google.maps.DrivingOptions|Object.<string>}
+ * @type {google.maps.DrivingOptions|Object.<string>|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.drivingOptions;
 
 /**
- * @type {Array<string|google.maps.LatLng|google.maps.Place>}
+ * @type {Array<(string|google.maps.LatLng|google.maps.Place)>}
  */
 google.maps.DistanceMatrixRequest.prototype.origins;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.region;
 
 /**
- * @type {google.maps.TransitOptions|Object.<string>}
+ * @type {google.maps.TransitOptions|Object.<string>|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.transitOptions;
 
@@ -1453,12 +1515,12 @@ google.maps.DistanceMatrixRequest.prototype.transitOptions;
 google.maps.DistanceMatrixRequest.prototype.travelMode;
 
 /**
- * @type {google.maps.UnitSystem}
+ * @type {google.maps.UnitSystem|undefined}
  */
 google.maps.DistanceMatrixRequest.prototype.unitSystem;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DistanceMatrixResponse = function() {};
 
@@ -1478,7 +1540,7 @@ google.maps.DistanceMatrixResponse.prototype.originAddresses;
 google.maps.DistanceMatrixResponse.prototype.rows;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DistanceMatrixResponseElement = function() {};
 
@@ -1508,7 +1570,7 @@ google.maps.DistanceMatrixResponseElement.prototype.fare;
 google.maps.DistanceMatrixResponseElement.prototype.status;
 
 /**
- * @interface
+ * @record
  */
 google.maps.DistanceMatrixResponseRow = function() {};
 
@@ -1543,7 +1605,7 @@ google.maps.DistanceMatrixStatus = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.DrivingOptions = function() {};
 
@@ -1553,12 +1615,12 @@ google.maps.DrivingOptions = function() {};
 google.maps.DrivingOptions.prototype.departureTime;
 
 /**
- * @type {google.maps.TrafficModel}
+ * @type {google.maps.TrafficModel|undefined}
  */
 google.maps.DrivingOptions.prototype.trafficModel;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Duration = function() {};
 
@@ -1573,7 +1635,7 @@ google.maps.Duration.prototype.text;
 google.maps.Duration.prototype.value;
 
 /**
- * @interface
+ * @record
  */
 google.maps.ElevationResult = function() {};
 
@@ -1623,7 +1685,7 @@ google.maps.ElevationStatus = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.FullscreenControlOptions = function() {};
 
@@ -1633,7 +1695,7 @@ google.maps.FullscreenControlOptions = function() {};
 google.maps.FullscreenControlOptions.prototype.position;
 
 /**
- * @interface
+ * @record
  */
 google.maps.FusionTablesCell = function() {};
 
@@ -1683,7 +1745,7 @@ google.maps.FusionTablesLayer.prototype.setMap = function(map) {};
 google.maps.FusionTablesLayer.prototype.setOptions = function(options) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.FusionTablesLayerOptions = function() {};
 
@@ -1728,7 +1790,7 @@ google.maps.FusionTablesMarkerOptions = function() {};
 google.maps.FusionTablesMarkerOptions.prototype.iconName;
 
 /**
- * @interface
+ * @record
  */
 google.maps.FusionTablesMouseEvent = function() {};
 
@@ -1895,7 +1957,7 @@ google.maps.GeocoderAddressComponent.prototype.short_name;
 google.maps.GeocoderAddressComponent.prototype.types;
 
 /**
- * @interface
+ * @record
  */
 google.maps.GeocoderComponentRestrictions = function() {};
 
@@ -1960,7 +2022,7 @@ google.maps.GeocoderLocationType = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.GeocoderRequest = function() {};
 
@@ -2093,7 +2155,7 @@ google.maps.GroundOverlay.prototype.setMap = function(map) {};
 google.maps.GroundOverlay.prototype.setOpacity = function(opacity) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.GroundOverlayOptions = function() {};
 
@@ -2113,7 +2175,7 @@ google.maps.GroundOverlayOptions.prototype.map;
 google.maps.GroundOverlayOptions.prototype.opacity;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Icon = function() {};
 
@@ -2148,7 +2210,18 @@ google.maps.Icon.prototype.size;
 google.maps.Icon.prototype.url;
 
 /**
- * @interface
+ * @extends {google.maps.MouseEvent}
+ * @constructor
+ */
+google.maps.IconMouseEvent = function() {};
+
+/**
+ * @type {string}
+ */
+google.maps.IconMouseEvent.prototype.placeId;
+
+/**
+ * @record
  */
 google.maps.IconSequence = function() {};
 
@@ -2226,12 +2299,14 @@ google.maps.ImageMapType.prototype.getOpacity = function() {};
  * @param {number} zoom
  * @param {Document} ownerDocument
  * @return {Node}
+ * @override
  */
 google.maps.ImageMapType.prototype.getTile = function(tileCoord, zoom, ownerDocument) {};
 
 /**
  * @param {Node} tileDiv
  * @return {undefined}
+ * @override
  */
 google.maps.ImageMapType.prototype.releaseTile = function(tileDiv) {};
 
@@ -2242,7 +2317,7 @@ google.maps.ImageMapType.prototype.releaseTile = function(tileDiv) {};
 google.maps.ImageMapType.prototype.setOpacity = function(opacity) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.ImageMapTypeOptions = function() {};
 
@@ -2343,7 +2418,7 @@ google.maps.InfoWindow.prototype.setPosition = function(position) {};
 google.maps.InfoWindow.prototype.setZIndex = function(zIndex) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.InfoWindowOptions = function() {};
 
@@ -2530,7 +2605,7 @@ google.maps.KmlLayerMetadata.prototype.name;
 google.maps.KmlLayerMetadata.prototype.snippet;
 
 /**
- * @interface
+ * @record
  */
 google.maps.KmlLayerOptions = function() {};
 
@@ -2630,11 +2705,13 @@ google.maps.LatLng.prototype.lng = function() {};
 
 /**
  * @return {google.maps.LatLngLiteral}
+ * @override
  */
 google.maps.LatLng.prototype.toJSON = function() {};
 
 /**
  * @return {string}
+ * @override
  */
 google.maps.LatLng.prototype.toString = function() {};
 
@@ -2652,7 +2729,7 @@ google.maps.LatLng.prototype.toUrlValue = function(opt_precision) {};
 google.maps.LatLngBounds = function(opt_sw, opt_ne) {};
 
 /**
- * @param {google.maps.LatLng} latLng
+ * @param {google.maps.LatLng|google.maps.LatLngLiteral} latLng
  * @return {boolean}
  */
 google.maps.LatLngBounds.prototype.contains = function(latLng) {};
@@ -2664,7 +2741,7 @@ google.maps.LatLngBounds.prototype.contains = function(latLng) {};
 google.maps.LatLngBounds.prototype.equals = function(other) {};
 
 /**
- * @param {google.maps.LatLng} point
+ * @param {google.maps.LatLng|google.maps.LatLngLiteral} point
  * @return {google.maps.LatLngBounds}
  */
 google.maps.LatLngBounds.prototype.extend = function(point) {};
@@ -2700,6 +2777,7 @@ google.maps.LatLngBounds.prototype.isEmpty = function() {};
 
 /**
  * @return {google.maps.LatLngBoundsLiteral}
+ * @override
  */
 google.maps.LatLngBounds.prototype.toJSON = function() {};
 
@@ -2710,6 +2788,7 @@ google.maps.LatLngBounds.prototype.toSpan = function() {};
 
 /**
  * @return {string}
+ * @override
  */
 google.maps.LatLngBounds.prototype.toString = function() {};
 
@@ -2726,7 +2805,7 @@ google.maps.LatLngBounds.prototype.toUrlValue = function(opt_precision) {};
 google.maps.LatLngBounds.prototype.union = function(other) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.LatLngBoundsLiteral = function() {};
 
@@ -2751,7 +2830,7 @@ google.maps.LatLngBoundsLiteral.prototype.south;
 google.maps.LatLngBoundsLiteral.prototype.west;
 
 /**
- * @interface
+ * @record
  */
 google.maps.LatLngLiteral = function() {};
 
@@ -2766,7 +2845,7 @@ google.maps.LatLngLiteral.prototype.lat;
 google.maps.LatLngLiteral.prototype.lng;
 
 /**
- * @interface
+ * @record
  */
 google.maps.LocationElevationRequest = function() {};
 
@@ -2883,16 +2962,16 @@ google.maps.MVCObject.prototype.notify = function(key) {};
 
 /**
  * @param {string} key
- * @param {?} value
+ * @param {?=} opt_value
  * @return {undefined}
  */
-google.maps.MVCObject.prototype.set = function(key, value) {};
+google.maps.MVCObject.prototype.set = function(key, opt_value) {};
 
 /**
- * @param {Object|undefined} values
+ * @param {Object=} opt_values
  * @return {undefined}
  */
-google.maps.MVCObject.prototype.setValues = function(values) {};
+google.maps.MVCObject.prototype.setValues = function(opt_values) {};
 
 /**
  * @param {string} key
@@ -3105,7 +3184,7 @@ google.maps.MapCanvasProjection.prototype.fromLatLngToDivPixel = function(latLng
 google.maps.MapCanvasProjection.prototype.getWorldWidth = function() {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.MapOptions = function() {};
 
@@ -3168,11 +3247,6 @@ google.maps.MapOptions.prototype.heading;
  * @type {boolean}
  */
 google.maps.MapOptions.prototype.keyboardShortcuts;
-
-/**
- * @type {boolean}
- */
-google.maps.MapOptions.prototype.mapMaker;
 
 /**
  * @type {boolean}
@@ -3315,7 +3389,7 @@ google.maps.MapPanes.prototype.overlayLayer;
 google.maps.MapPanes.prototype.overlayMouseTarget;
 
 /**
- * @interface
+ * @record
  */
 google.maps.MapType = function() {};
 
@@ -3369,7 +3443,7 @@ google.maps.MapType.prototype.getTile = function(tileCoord, zoom, ownerDocument)
 google.maps.MapType.prototype.releaseTile = function(tile) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.MapTypeControlOptions = function() {};
 
@@ -3415,14 +3489,14 @@ google.maps.MapTypeRegistry = function() {};
 
 /**
  * @param {string} id
- * @param {google.maps.MapType|undefined} mapType
+ * @param {google.maps.MapType=} opt_mapType
  * @return {undefined}
  * @override
  */
-google.maps.MapTypeRegistry.prototype.set = function(id, mapType) {};
+google.maps.MapTypeRegistry.prototype.set = function(id, opt_mapType) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.MapTypeStyle = function() {};
 
@@ -3437,54 +3511,9 @@ google.maps.MapTypeStyle.prototype.elementType;
 google.maps.MapTypeStyle.prototype.featureType;
 
 /**
- * @type {Array<google.maps.MapTypeStyler>}
+ * @type {Array<Object>}
  */
 google.maps.MapTypeStyle.prototype.stylers;
-
-/**
- * @interface
- */
-google.maps.MapTypeStyler = function() {};
-
-/**
- * @type {string}
- */
-google.maps.MapTypeStyler.prototype.color;
-
-/**
- * @type {number}
- */
-google.maps.MapTypeStyler.prototype.gamma;
-
-/**
- * @type {string}
- */
-google.maps.MapTypeStyler.prototype.hue;
-
-/**
- * @type {boolean}
- */
-google.maps.MapTypeStyler.prototype.invert_lightness;
-
-/**
- * @type {number}
- */
-google.maps.MapTypeStyler.prototype.lightness;
-
-/**
- * @type {number}
- */
-google.maps.MapTypeStyler.prototype.saturation;
-
-/**
- * @type {string}
- */
-google.maps.MapTypeStyler.prototype.visibility;
-
-/**
- * @type {number}
- */
-google.maps.MapTypeStyler.prototype.weight;
 
 /**
  * @constructor
@@ -3696,7 +3725,7 @@ google.maps.Marker.prototype.setZIndex = function(zIndex) {};
 google.maps.Marker.MAX_ZINDEX;
 
 /**
- * @interface
+ * @record
  */
 google.maps.MarkerLabel = function() {};
 
@@ -3726,7 +3755,7 @@ google.maps.MarkerLabel.prototype.fontWeight;
 google.maps.MarkerLabel.prototype.text;
 
 /**
- * @interface
+ * @record
  */
 google.maps.MarkerOptions = function() {};
 
@@ -3821,7 +3850,7 @@ google.maps.MarkerOptions.prototype.visible;
 google.maps.MarkerOptions.prototype.zIndex;
 
 /**
- * @interface
+ * @record
  */
 google.maps.MarkerPlace = function() {};
 
@@ -3841,7 +3870,7 @@ google.maps.MarkerPlace.prototype.placeId;
 google.maps.MarkerPlace.prototype.query;
 
 /**
- * @interface
+ * @record
  */
 google.maps.MarkerShape = function() {};
 
@@ -3856,7 +3885,7 @@ google.maps.MarkerShape.prototype.coords;
 google.maps.MarkerShape.prototype.type;
 
 /**
- * @interface
+ * @record
  */
 google.maps.MaxZoomResult = function() {};
 
@@ -3889,6 +3918,16 @@ google.maps.MaxZoomStatus = {
   ERROR: '0',
   OK: '1'
 };
+
+/**
+ * @record
+ */
+google.maps.MotionTrackingControlOptions = function() {};
+
+/**
+ * @type {google.maps.ControlPosition}
+ */
+google.maps.MotionTrackingControlOptions.prototype.position;
 
 /**
  * @constructor
@@ -3951,7 +3990,7 @@ google.maps.OverlayView.prototype.onRemove = function() {};
 google.maps.OverlayView.prototype.setMap = function(map) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.PanControlOptions = function() {};
 
@@ -3961,7 +4000,17 @@ google.maps.PanControlOptions = function() {};
 google.maps.PanControlOptions.prototype.position;
 
 /**
- * @interface
+ * @record
+ */
+google.maps.PanoProviderOptions = function() {};
+
+/**
+ * @type {boolean|undefined}
+ */
+google.maps.PanoProviderOptions.prototype.cors;
+
+/**
+ * @record
  */
 google.maps.PathElevationRequest = function() {};
 
@@ -3976,22 +4025,22 @@ google.maps.PathElevationRequest.prototype.path;
 google.maps.PathElevationRequest.prototype.samples;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Place = function() {};
 
 /**
- * @type {google.maps.LatLng|google.maps.LatLngLiteral}
+ * @type {google.maps.LatLng|google.maps.LatLngLiteral|undefined}
  */
 google.maps.Place.prototype.location;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Place.prototype.placeId;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.Place.prototype.query;
 
@@ -4020,6 +4069,7 @@ google.maps.Point.prototype.equals = function(other) {};
 
 /**
  * @return {string}
+ * @override
  */
 google.maps.Point.prototype.toString = function() {};
 
@@ -4130,7 +4180,7 @@ google.maps.Polygon.prototype.setPaths = function(paths) {};
 google.maps.Polygon.prototype.setVisible = function(visible) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.PolygonOptions = function() {};
 
@@ -4278,7 +4328,7 @@ google.maps.Polyline.prototype.setPath = function(path) {};
 google.maps.Polyline.prototype.setVisible = function(visible) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.PolylineOptions = function() {};
 
@@ -4343,7 +4393,7 @@ google.maps.PolylineOptions.prototype.visible;
 google.maps.PolylineOptions.prototype.zIndex;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Projection = function() {};
 
@@ -4435,7 +4485,7 @@ google.maps.Rectangle.prototype.setOptions = function(options) {};
 google.maps.Rectangle.prototype.setVisible = function(visible) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.RectangleOptions = function() {};
 
@@ -4505,7 +4555,7 @@ google.maps.RectangleOptions.prototype.visible;
 google.maps.RectangleOptions.prototype.zIndex;
 
 /**
- * @interface
+ * @record
  */
 google.maps.RotateControlOptions = function() {};
 
@@ -4553,7 +4603,7 @@ google.maps.SaveWidget.prototype.setOptions = function(opts) {};
 google.maps.SaveWidget.prototype.setPlace = function(place) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.SaveWidgetOptions = function() {};
 
@@ -4568,7 +4618,7 @@ google.maps.SaveWidgetOptions.prototype.attribution;
 google.maps.SaveWidgetOptions.prototype.place;
 
 /**
- * @interface
+ * @record
  */
 google.maps.ScaleControlOptions = function() {};
 
@@ -4611,11 +4661,12 @@ google.maps.Size.prototype.equals = function(other) {};
 
 /**
  * @return {string}
+ * @override
  */
 google.maps.Size.prototype.toString = function() {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewAddressControlOptions = function() {};
 
@@ -4625,7 +4676,7 @@ google.maps.StreetViewAddressControlOptions = function() {};
 google.maps.StreetViewAddressControlOptions.prototype.position;
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewControlOptions = function() {};
 
@@ -4653,7 +4704,7 @@ google.maps.StreetViewCoverageLayer.prototype.getMap = function() {};
 google.maps.StreetViewCoverageLayer.prototype.setMap = function(map) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewLink = function() {};
 
@@ -4673,7 +4724,7 @@ google.maps.StreetViewLink.prototype.heading;
 google.maps.StreetViewLink.prototype.pano;
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewLocation = function() {};
 
@@ -4698,7 +4749,7 @@ google.maps.StreetViewLocation.prototype.pano;
 google.maps.StreetViewLocation.prototype.shortDescription;
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewLocationRequest = function() {};
 
@@ -4723,7 +4774,7 @@ google.maps.StreetViewLocationRequest.prototype.radius;
 google.maps.StreetViewLocationRequest.prototype.source;
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewPanoRequest = function() {};
 
@@ -4756,6 +4807,12 @@ google.maps.StreetViewPanorama.prototype.getLinks = function() {};
  * @return {google.maps.StreetViewLocation}
  */
 google.maps.StreetViewPanorama.prototype.getLocation = function() {};
+
+/**
+ * @nosideeffects
+ * @return {boolean}
+ */
+google.maps.StreetViewPanorama.prototype.getMotionTracking = function() {};
 
 /**
  * @nosideeffects
@@ -4801,15 +4858,22 @@ google.maps.StreetViewPanorama.prototype.getZoom = function() {};
 
 /**
  * @param {function(string):google.maps.StreetViewPanoramaData} provider
+ * @param {(google.maps.PanoProviderOptions|Object.<string>)=} opt_opt_options
  * @return {undefined}
  */
-google.maps.StreetViewPanorama.prototype.registerPanoProvider = function(provider) {};
+google.maps.StreetViewPanorama.prototype.registerPanoProvider = function(provider, opt_opt_options) {};
 
 /**
  * @param {Array<google.maps.StreetViewLink>} links
  * @return {undefined}
  */
 google.maps.StreetViewPanorama.prototype.setLinks = function(links) {};
+
+/**
+ * @param {boolean} motionTracking
+ * @return {undefined}
+ */
+google.maps.StreetViewPanorama.prototype.setMotionTracking = function(motionTracking) {};
 
 /**
  * @param {google.maps.StreetViewPanoramaOptions|Object.<string>} options
@@ -4848,7 +4912,7 @@ google.maps.StreetViewPanorama.prototype.setVisible = function(flag) {};
 google.maps.StreetViewPanorama.prototype.setZoom = function(zoom) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewPanoramaData = function() {};
 
@@ -4878,7 +4942,7 @@ google.maps.StreetViewPanoramaData.prototype.location;
 google.maps.StreetViewPanoramaData.prototype.tiles;
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewPanoramaOptions = function() {};
 
@@ -4935,6 +4999,16 @@ google.maps.StreetViewPanoramaOptions.prototype.linksControl;
 /**
  * @type {boolean}
  */
+google.maps.StreetViewPanoramaOptions.prototype.motionTracking;
+
+/**
+ * @type {boolean}
+ */
+google.maps.StreetViewPanoramaOptions.prototype.motionTrackingControl;
+
+/**
+ * @type {boolean}
+ */
 google.maps.StreetViewPanoramaOptions.prototype.panControl;
 
 /**
@@ -4946,11 +5020,6 @@ google.maps.StreetViewPanoramaOptions.prototype.panControlOptions;
  * @type {string}
  */
 google.maps.StreetViewPanoramaOptions.prototype.pano;
-
-/**
- * @type {function(string): google.maps.StreetViewPanoramaData}
- */
-google.maps.StreetViewPanoramaOptions.prototype.panoProvider;
 
 /**
  * @type {google.maps.LatLng|google.maps.LatLngLiteral}
@@ -4966,6 +5035,11 @@ google.maps.StreetViewPanoramaOptions.prototype.pov;
  * @type {boolean}
  */
 google.maps.StreetViewPanoramaOptions.prototype.scrollwheel;
+
+/**
+ * @type {boolean}
+ */
+google.maps.StreetViewPanoramaOptions.prototype.showRoadLabels;
 
 /**
  * @type {boolean}
@@ -5035,7 +5109,7 @@ google.maps.StreetViewStatus = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.StreetViewTileData = function() {};
 
@@ -5121,17 +5195,19 @@ google.maps.StyledMapType.prototype.tileSize;
  * @param {number} zoom
  * @param {Document} ownerDocument
  * @return {Node}
+ * @override
  */
 google.maps.StyledMapType.prototype.getTile = function(tileCoord, zoom, ownerDocument) {};
 
 /**
  * @param {Node} tile
  * @return {undefined}
+ * @override
  */
 google.maps.StyledMapType.prototype.releaseTile = function(tile) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.StyledMapTypeOptions = function() {};
 
@@ -5156,7 +5232,7 @@ google.maps.StyledMapTypeOptions.prototype.minZoom;
 google.maps.StyledMapTypeOptions.prototype.name;
 
 /**
- * @interface
+ * @record
  */
 google.maps.Symbol = function() {};
 
@@ -5222,7 +5298,7 @@ google.maps.SymbolPath = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.Time = function() {};
 
@@ -5267,9 +5343,14 @@ google.maps.TrafficLayer.prototype.setMap = function(map) {};
 google.maps.TrafficLayer.prototype.setOptions = function(options) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.TrafficLayerOptions = function() {};
+
+/**
+ * @type {boolean}
+ */
+google.maps.TrafficLayerOptions.prototype.autoRefresh;
 
 /**
  * @type {google.maps.Map}
@@ -5286,7 +5367,7 @@ google.maps.TrafficModel = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitAgency = function() {};
 
@@ -5306,7 +5387,7 @@ google.maps.TransitAgency.prototype.phone;
 google.maps.TransitAgency.prototype.url;
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitDetails = function() {};
 
@@ -5351,9 +5432,19 @@ google.maps.TransitDetails.prototype.line;
 google.maps.TransitDetails.prototype.num_stops;
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitFare = function() {};
+
+/**
+ * @type {string}
+ */
+google.maps.TransitFare.prototype.currency;
+
+/**
+ * @type {number}
+ */
+google.maps.TransitFare.prototype.value;
 
 /**
  * @extends {google.maps.MVCObject}
@@ -5374,7 +5465,7 @@ google.maps.TransitLayer.prototype.getMap = function() {};
 google.maps.TransitLayer.prototype.setMap = function(map) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitLine = function() {};
 
@@ -5430,27 +5521,27 @@ google.maps.TransitMode = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitOptions = function() {};
 
 /**
- * @type {Date}
+ * @type {Date|undefined}
  */
 google.maps.TransitOptions.prototype.arrivalTime;
 
 /**
- * @type {Date}
+ * @type {Date|undefined}
  */
 google.maps.TransitOptions.prototype.departureTime;
 
 /**
- * @type {Array<google.maps.TransitMode>}
+ * @type {Array<google.maps.TransitMode>|undefined}
  */
 google.maps.TransitOptions.prototype.modes;
 
 /**
- * @type {google.maps.TransitRoutePreference}
+ * @type {google.maps.TransitRoutePreference|undefined}
  */
 google.maps.TransitOptions.prototype.routingPreference;
 
@@ -5463,7 +5554,7 @@ google.maps.TransitRoutePreference = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitStop = function() {};
 
@@ -5478,7 +5569,7 @@ google.maps.TransitStop.prototype.location;
 google.maps.TransitStop.prototype.name;
 
 /**
- * @interface
+ * @record
  */
 google.maps.TransitVehicle = function() {};
 
@@ -5521,7 +5612,7 @@ google.maps.UnitSystem = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.ZoomControlOptions = function() {};
 
@@ -5534,7 +5625,7 @@ google.maps.ZoomControlOptions.prototype.position;
 google.maps.drawing = {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.drawing.DrawingControlOptions = function() {};
 
@@ -5586,7 +5677,7 @@ google.maps.drawing.DrawingManager.prototype.setMap = function(map) {};
 google.maps.drawing.DrawingManager.prototype.setOptions = function(options) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.drawing.DrawingManagerOptions = function() {};
 
@@ -5868,7 +5959,7 @@ google.maps.places.Autocomplete.prototype.setComponentRestrictions = function(re
 google.maps.places.Autocomplete.prototype.setTypes = function(types) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.AutocompleteOptions = function() {};
 
@@ -5878,17 +5969,17 @@ google.maps.places.AutocompleteOptions = function() {};
 google.maps.places.AutocompleteOptions.prototype.bounds;
 
 /**
- * @type {google.maps.places.ComponentRestrictions}
+ * @type {google.maps.places.ComponentRestrictions|undefined}
  */
 google.maps.places.AutocompleteOptions.prototype.componentRestrictions;
 
 /**
- * @type {Array<string>}
+ * @type {Array<string>|undefined}
  */
 google.maps.places.AutocompleteOptions.prototype.types;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.AutocompletePrediction = function() {};
 
@@ -5937,17 +6028,17 @@ google.maps.places.AutocompleteService.prototype.getPlacePredictions = function(
 google.maps.places.AutocompleteService.prototype.getQueryPredictions = function(request, callback) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.AutocompletionRequest = function() {};
 
 /**
- * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral}
+ * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral|undefined}
  */
 google.maps.places.AutocompletionRequest.prototype.bounds;
 
 /**
- * @type {google.maps.places.ComponentRestrictions}
+ * @type {google.maps.places.ComponentRestrictions|undefined}
  */
 google.maps.places.AutocompletionRequest.prototype.componentRestrictions;
 
@@ -5957,7 +6048,7 @@ google.maps.places.AutocompletionRequest.prototype.componentRestrictions;
 google.maps.places.AutocompletionRequest.prototype.input;
 
 /**
- * @type {google.maps.LatLng}
+ * @type {google.maps.LatLng|undefined}
  */
 google.maps.places.AutocompletionRequest.prototype.location;
 
@@ -5967,17 +6058,17 @@ google.maps.places.AutocompletionRequest.prototype.location;
 google.maps.places.AutocompletionRequest.prototype.offset;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.AutocompletionRequest.prototype.radius;
 
 /**
- * @type {Array<string>}
+ * @type {Array<string>|undefined}
  */
 google.maps.places.AutocompletionRequest.prototype.types;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.ComponentRestrictions = function() {};
 
@@ -6017,7 +6108,7 @@ google.maps.places.PlaceAspectRating.prototype.rating;
 google.maps.places.PlaceAspectRating.prototype.type;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PlaceDetailsRequest = function() {};
 
@@ -6027,7 +6118,7 @@ google.maps.places.PlaceDetailsRequest = function() {};
 google.maps.places.PlaceDetailsRequest.prototype.placeId;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PlaceGeometry = function() {};
 
@@ -6037,12 +6128,12 @@ google.maps.places.PlaceGeometry = function() {};
 google.maps.places.PlaceGeometry.prototype.location;
 
 /**
- * @type {google.maps.LatLngBounds}
+ * @type {google.maps.LatLngBounds|undefined}
  */
 google.maps.places.PlaceGeometry.prototype.viewport;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PlacePhoto = function() {};
 
@@ -6068,7 +6159,7 @@ google.maps.places.PlacePhoto.prototype.width;
 google.maps.places.PlacePhoto.prototype.getUrl = function(opts) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PlaceResult = function() {};
 
@@ -6118,7 +6209,7 @@ google.maps.places.PlaceResult.prototype.international_phone_number;
 google.maps.places.PlaceResult.prototype.name;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.places.PlaceResult.prototype.permanently_closed;
 
@@ -6218,57 +6309,57 @@ google.maps.places.PlaceSearchPagination.prototype.hasNextPage;
 google.maps.places.PlaceSearchPagination.prototype.nextPage = function() {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PlaceSearchRequest = function() {};
 
 /**
- * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral}
+ * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.bounds;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.keyword;
 
 /**
- * @type {google.maps.LatLng|google.maps.LatLngLiteral}
+ * @type {google.maps.LatLng|google.maps.LatLngLiteral|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.location;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.maxPriceLevel;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.minPriceLevel;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.name;
 
 /**
- * @type {boolean}
+ * @type {boolean|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.openNow;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.radius;
 
 /**
- * @type {google.maps.places.RankBy}
+ * @type {google.maps.places.RankBy|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.rankBy;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.PlaceSearchRequest.prototype.type;
 
@@ -6288,7 +6379,7 @@ google.maps.places.PlacesService.prototype.getDetails = function(request, callba
 /**
  * @param {google.maps.places.PlaceSearchRequest|Object.<string>} request
  * @param {function(Array<google.maps.places.PlaceResult>, google.maps.places.PlacesServiceStatus,
-               google.maps.places.PlaceSearchPagination)} callback
+    google.maps.places.PlaceSearchPagination)} callback
  * @return {undefined}
  */
 google.maps.places.PlacesService.prototype.nearbySearch = function(request, callback) {};
@@ -6303,7 +6394,7 @@ google.maps.places.PlacesService.prototype.radarSearch = function(request, callb
 /**
  * @param {google.maps.places.TextSearchRequest|Object.<string>} request
  * @param {function(Array<google.maps.places.PlaceResult>, google.maps.places.PlacesServiceStatus,
-   google.maps.places.PlaceSearchPagination)} callback
+    google.maps.places.PlaceSearchPagination)} callback
  * @return {undefined}
  */
 google.maps.places.PlacesService.prototype.textSearch = function(request, callback) {};
@@ -6321,7 +6412,7 @@ google.maps.places.PlacesServiceStatus = {
 };
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PredictionSubstring = function() {};
 
@@ -6336,7 +6427,7 @@ google.maps.places.PredictionSubstring.prototype.length;
 google.maps.places.PredictionSubstring.prototype.offset;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.PredictionTerm = function() {};
 
@@ -6351,7 +6442,7 @@ google.maps.places.PredictionTerm.prototype.offset;
 google.maps.places.PredictionTerm.prototype.value;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.QueryAutocompletePrediction = function() {};
 
@@ -6366,7 +6457,7 @@ google.maps.places.QueryAutocompletePrediction.prototype.description;
 google.maps.places.QueryAutocompletePrediction.prototype.matched_substrings;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.QueryAutocompletePrediction.prototype.place_id;
 
@@ -6376,12 +6467,12 @@ google.maps.places.QueryAutocompletePrediction.prototype.place_id;
 google.maps.places.QueryAutocompletePrediction.prototype.terms;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.QueryAutocompletionRequest = function() {};
 
 /**
- * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral}
+ * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral|undefined}
  */
 google.maps.places.QueryAutocompletionRequest.prototype.bounds;
 
@@ -6391,7 +6482,7 @@ google.maps.places.QueryAutocompletionRequest.prototype.bounds;
 google.maps.places.QueryAutocompletionRequest.prototype.input;
 
 /**
- * @type {google.maps.LatLng}
+ * @type {google.maps.LatLng|undefined}
  */
 google.maps.places.QueryAutocompletionRequest.prototype.location;
 
@@ -6401,42 +6492,42 @@ google.maps.places.QueryAutocompletionRequest.prototype.location;
 google.maps.places.QueryAutocompletionRequest.prototype.offset;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.QueryAutocompletionRequest.prototype.radius;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.RadarSearchRequest = function() {};
 
 /**
- * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral}
+ * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral|undefined}
  */
 google.maps.places.RadarSearchRequest.prototype.bounds;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.RadarSearchRequest.prototype.keyword;
 
 /**
- * @type {google.maps.LatLng|google.maps.LatLngLiteral}
+ * @type {google.maps.LatLng|google.maps.LatLngLiteral|undefined}
  */
 google.maps.places.RadarSearchRequest.prototype.location;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.RadarSearchRequest.prototype.name;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.RadarSearchRequest.prototype.radius;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.RadarSearchRequest.prototype.type;
 
@@ -6475,7 +6566,7 @@ google.maps.places.SearchBox.prototype.getPlaces = function() {};
 google.maps.places.SearchBox.prototype.setBounds = function(bounds) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.SearchBoxOptions = function() {};
 
@@ -6485,32 +6576,32 @@ google.maps.places.SearchBoxOptions = function() {};
 google.maps.places.SearchBoxOptions.prototype.bounds;
 
 /**
- * @interface
+ * @record
  */
 google.maps.places.TextSearchRequest = function() {};
 
 /**
- * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral}
+ * @type {google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral|undefined}
  */
 google.maps.places.TextSearchRequest.prototype.bounds;
 
 /**
- * @type {google.maps.LatLng|google.maps.LatLngLiteral}
+ * @type {google.maps.LatLng|google.maps.LatLngLiteral|undefined}
  */
 google.maps.places.TextSearchRequest.prototype.location;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.TextSearchRequest.prototype.query;
 
 /**
- * @type {number}
+ * @type {number|undefined}
  */
 google.maps.places.TextSearchRequest.prototype.radius;
 
 /**
- * @type {string}
+ * @type {string|undefined}
  */
 google.maps.places.TextSearchRequest.prototype.type;
 
@@ -6556,7 +6647,7 @@ google.maps.visualization.HeatmapLayer.prototype.setMap = function(map) {};
 google.maps.visualization.HeatmapLayer.prototype.setOptions = function(options) {};
 
 /**
- * @interface
+ * @record
  */
 google.maps.visualization.HeatmapLayerOptions = function() {};
 
@@ -6596,7 +6687,7 @@ google.maps.visualization.HeatmapLayerOptions.prototype.opacity;
 google.maps.visualization.HeatmapLayerOptions.prototype.radius;
 
 /**
- * @interface
+ * @record
  */
 google.maps.visualization.WeightedLocation = function() {};
 
@@ -6609,4 +6700,3 @@ google.maps.visualization.WeightedLocation.prototype.location;
  * @type {number}
  */
 google.maps.visualization.WeightedLocation.prototype.weight;
-


### PR DESCRIPTION
This PR upgrades the Google Maps API file from 3.24 to 3.26.