### PR TITLE
Fix map synchronization

### DIFF
--- a/src/herald/viewherald.js
+++ b/src/herald/viewherald.js
@@ -167,9 +167,7 @@ olgm.herald.View.prototype.setZoom = function() {
   var resolution = this.ol3map.getView().getResolution();
   if (goog.isNumber(resolution)) {
     var zoom = olgm.getZoomFromResolution(resolution);
-    if (zoom !== null) {
-      this.gmap.setZoom(zoom);
-    }
+    this.gmap.setZoom(zoom);
   }
 };
 

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -135,22 +135,38 @@ olgm.getStyleOf = function(object) {
 
 /**
  * @param {number} resolution the resolution to get the zoom from
- * @return {?number} the zoom from the resolution, if found
+ * @return {number} the zoom from the resolution, which can be fractionnal
  */
 olgm.getZoomFromResolution = function(resolution) {
 
-  var found = null;
-  var precision = 1000;
-  var res = Math.round(resolution * precision) / precision;
+  var resolutions = olgm.RESOLUTIONS;
+  var zoom;
 
-  for (var z = 0, len = olgm.RESOLUTIONS.length; z < len; z++) {
-    if (res == Math.round(olgm.RESOLUTIONS[z] * precision) / precision) {
-      found = z;
+  var lowZoom = 0;
+  var highZoom = resolutions.length - 1;
+  var highRes = resolutions[lowZoom];
+  var lowRes = resolutions[highZoom];
+  var res;
+  for (var i = 0, len = resolutions.length; i < len; ++i) {
+    res = resolutions[i];
+    if (res >= resolution) {
+      highRes = res;
+      lowZoom = i;
+    }
+    if (res <= resolution) {
+      lowRes = res;
+      highZoom = i;
       break;
     }
   }
+  var dRes = highRes - lowRes;
+  if (dRes > 0) {
+    zoom = lowZoom + ((highRes - resolution) / dRes);
+  } else {
+    zoom = lowZoom;
+  }
 
-  return found;
+  return Math.round(zoom * 1000) / 1000;
 };
 
 


### PR DESCRIPTION
This patch fixes the map synchronization that changed in OpenLayers 3.20. See: https://github.com/openlayers/ol3/releases/tag/v3.20.0

In 3.20, the position of the map (center and resolution) changes **while** animating.  This used to be **at the end** prior to 3.20.