### PR TITLE
Attempt to upgrade to OpenLayers 4.1.1

### DIFF
--- a/build/serve.js
+++ b/build/serve.js
@@ -22,7 +22,7 @@ var createServer = exports.createServer = function(callback, loadTests) {
   var manager = new closure.Manager({
     closure: true, // use the bundled Closure Library
     lib: lib,
-    ignoreRequires: '^ol\\.'
+    ignoreRequires: 'ol'
   });
   manager.on('error', function(e) {
     log.error('ol3-google-maps', e.message);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "closure-util": "1.15.1",
+    "closure-util": "1.18.0",
     "geojsonhint": "^1.0.0",
     "eslint": "3.12.0",
     "eslint-config-openlayers": "6.0.0",
@@ -41,7 +41,7 @@
     "jsdoc": "~3.4.0",
     "mocha": "2.5.3",
     "mocha-phantomjs-core": "^1.3.1",
-    "openlayers": "3.20.0",
+    "openlayers": "4.1.1",
     "phantomjs-prebuilt": "2.1.7",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",

--- a/src/gm/gm.js
+++ b/src/gm/gm.js
@@ -1,6 +1,7 @@
 goog.provide('olgm.gm');
 
 goog.require('goog.asserts');
+goog.require('ol.proj');
 goog.require('olgm');
 goog.require('olgm.gm.MapLabel');
 goog.require('olgm.gm.MapIcon');

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -1,8 +1,7 @@
 goog.provide('olgm.gm.ImageOverlay');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
-
+goog.require('ol');
 
 /**
  * Creates a new image overlay.

--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -51,6 +51,7 @@ if (window.google && window.google.maps) {
 /**
  * Note: mark as `@api` to make the minimized version include this method.
  * @api
+ * @override
  */
 olgm.gm.ImageOverlay.prototype.onAdd = function() {
   var div = document.createElement('div');
@@ -82,6 +83,7 @@ olgm.gm.ImageOverlay.prototype.onAdd = function() {
 /**
  * Note: mark as `@api` to make the minimized version include this method.
  * @api
+ * @override
  */
 olgm.gm.ImageOverlay.prototype.draw = function() {
   var div = this.div_;
@@ -131,6 +133,7 @@ olgm.gm.ImageOverlay.prototype.setZIndex = function(zIndex) {
 /**
  * Note: mark as `@api` to make the minimized version include this method.
  * @api
+ * @override
  */
 olgm.gm.ImageOverlay.prototype.onRemove = function() {
   this.div_.parentNode.removeChild(this.div_);

--- a/src/gm/mapelement.js
+++ b/src/gm/mapelement.js
@@ -1,8 +1,7 @@
 goog.provide('olgm.gm.MapElement');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
-
+goog.require('ol');
 
 /**
  * This class is a parent for all elements that are drawn manually onto Google

--- a/src/gm/mapelement.js
+++ b/src/gm/mapelement.js
@@ -53,6 +53,7 @@ olgm.gm.MapElement.prototype.width_ = 0;
  * Draw features to the map (call redraw) and setup canvas if it's the first
  * time we draw
  * @api
+ * @override
  */
 olgm.gm.MapElement.prototype.draw = function() {
   if (this.drawn_) {
@@ -143,6 +144,7 @@ olgm.gm.MapElement.prototype.getVisible_ = function() {
 /**
  * Delete canvas when removing the element
  * @api
+ * @override
  */
 olgm.gm.MapElement.prototype.onRemove = function() {
   var canvas = this.canvas_;

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -35,6 +35,7 @@ ol.inherits(olgm.gm.MapIcon, olgm.gm.MapElement);
  * Listen to property changes and react accordingly
  * @param {string} prop property
  * @api
+ * @override
  */
 olgm.gm.MapIcon.prototype.changed = function(prop) {
   switch (prop) {
@@ -97,6 +98,7 @@ olgm.gm.MapIcon.prototype.drawCanvas_ = function() {
 /**
  * Manage feature being added to the map
  * @api
+ * @override
  */
 olgm.gm.MapIcon.prototype.onAdd = function() {
   var canvas = this.canvas_ = document.createElement('canvas');

--- a/src/gm/mapicon.js
+++ b/src/gm/mapicon.js
@@ -1,7 +1,7 @@
 goog.provide('olgm.gm.MapIcon');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
 goog.require('olgm.gm.MapElement');
 
 

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -34,7 +34,7 @@
 goog.provide('olgm.gm.MapLabel');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
 goog.require('olgm.gm.MapElement');
 
 

--- a/src/gm/maplabel.js
+++ b/src/gm/maplabel.js
@@ -64,6 +64,7 @@ ol.inherits(olgm.gm.MapLabel, olgm.gm.MapElement);
  * Note: mark as `@api` to make the minimized version include this method.
  * @param {string} prop property
  * @api
+ * @override
  */
 olgm.gm.MapLabel.prototype.changed = function(prop) {
   switch (prop) {
@@ -137,6 +138,7 @@ olgm.gm.MapLabel.prototype.drawCanvas_ = function() {
 /**
  * Note: mark as `@api` to make the minimized version include this method.
  * @api
+ * @override
  */
 olgm.gm.MapLabel.prototype.onAdd = function() {
   var canvas = this.canvas_ = document.createElement('canvas');

--- a/src/gm/panesoverlay.js
+++ b/src/gm/panesoverlay.js
@@ -33,6 +33,7 @@ olgm.gm.PanesOverlay.prototype.getMapPanes = function() {
 /**
  * Override parent function, but do not do anything
  * @api
+ * @override
  */
 olgm.gm.PanesOverlay.prototype.onAdd = function() {
 
@@ -42,6 +43,7 @@ olgm.gm.PanesOverlay.prototype.onAdd = function() {
 /**
  * Override parent function, but do not do anything
  * @api
+ * @override
  */
 olgm.gm.PanesOverlay.prototype.draw = function() {
 
@@ -51,6 +53,7 @@ olgm.gm.PanesOverlay.prototype.draw = function() {
 /**
  * Override parent function, but do not do anything
  * @api
+ * @override
  */
 olgm.gm.PanesOverlay.prototype.onRemove = function() {
 

--- a/src/gm/panesoverlay.js
+++ b/src/gm/panesoverlay.js
@@ -1,7 +1,7 @@
 goog.provide('olgm.gm.PanesOverlay');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
 
 
 /**

--- a/src/herald/featureherald.js
+++ b/src/herald/featureherald.js
@@ -2,7 +2,8 @@ goog.provide('olgm.herald.Feature');
 
 goog.require('goog.asserts');
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
+goog.require('ol.Observable');
 goog.require('olgm');
 goog.require('olgm.gm');
 goog.require('olgm.herald.Herald');

--- a/src/herald/herald.js
+++ b/src/herald/herald.js
@@ -1,7 +1,7 @@
 goog.provide('olgm.herald.Herald');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
 goog.require('olgm');
 goog.require('olgm.Abstract');
 

--- a/src/herald/imagewmssourceherald.js
+++ b/src/herald/imagewmssourceherald.js
@@ -1,7 +1,11 @@
 goog.provide('olgm.herald.ImageWMSSource');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('goog.asserts');
+goog.require('ol');
+goog.require('ol.extent');
+goog.require('ol.proj');
+goog.require('olgm');
 goog.require('olgm.gm.ImageOverlay');
 goog.require('olgm.herald.Source');
 

--- a/src/herald/layersherald.js
+++ b/src/herald/layersherald.js
@@ -1,6 +1,7 @@
 goog.provide('olgm.herald.Layers');
 
 goog.require('goog.asserts');
+goog.require('ol');
 goog.require('olgm');
 goog.require('olgm.herald.Herald');
 goog.require('olgm.herald.ImageWMSSource');

--- a/src/herald/sourceherald.js
+++ b/src/herald/sourceherald.js
@@ -1,7 +1,7 @@
 goog.provide('olgm.herald.Source');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
 goog.require('olgm.herald.Herald');
 
 

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -263,6 +263,7 @@ olgm.herald.TileSource.prototype.unwatchLayer = function(layer) {
 /**
  * Activate all cache items
  * @api
+ * @override
  */
 olgm.herald.TileSource.prototype.activate = function() {
   olgm.herald.Source.prototype.activate.call(this);
@@ -289,6 +290,7 @@ olgm.herald.TileSource.prototype.activateCacheItem_ = function(
 /**
  * Deactivate all cache items
  * @api
+ * @override
  */
 olgm.herald.TileSource.prototype.deactivate = function() {
   olgm.herald.Source.prototype.deactivate.call(this);

--- a/src/herald/tilesourceherald.js
+++ b/src/herald/tilesourceherald.js
@@ -1,7 +1,12 @@
 goog.provide('olgm.herald.TileSource');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('goog.asserts');
+goog.require('ol');
+goog.require('ol.extent');
+goog.require('ol.proj');
+goog.require('olgm');
+goog.require('olgm.gm');
 goog.require('olgm.gm.PanesOverlay');
 goog.require('olgm.herald.Source');
 

--- a/src/herald/vectorfeatureherald.js
+++ b/src/herald/vectorfeatureherald.js
@@ -2,7 +2,8 @@ goog.provide('olgm.herald.VectorFeature');
 
 goog.require('goog.asserts');
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
+goog.require('olgm');
 goog.require('olgm.herald.Feature');
 goog.require('olgm.herald.Herald');
 

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -131,6 +131,7 @@ olgm.herald.VectorSource.prototype.unwatchLayer = function(layer) {
 /**
  * Activate all cache items
  * @api
+ * @override
  */
 olgm.herald.VectorSource.prototype.activate = function() {
   olgm.herald.Source.prototype.activate.call(this);
@@ -157,6 +158,7 @@ olgm.herald.VectorSource.prototype.activateCacheItem_ = function(
 /**
  * Deactivate all cache items
  * @api
+ * @override
  */
 olgm.herald.VectorSource.prototype.deactivate = function() {
   olgm.herald.Source.prototype.deactivate.call(this);

--- a/src/herald/vectorsourceherald.js
+++ b/src/herald/vectorsourceherald.js
@@ -1,7 +1,10 @@
 goog.provide('olgm.herald.VectorSource');
 
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('goog.asserts');
+goog.require('ol');
+goog.require('olgm');
+goog.require('olgm.gm');
 goog.require('olgm.herald.Source');
 goog.require('olgm.herald.VectorFeature');
 

--- a/src/herald/viewherald.js
+++ b/src/herald/viewherald.js
@@ -4,7 +4,8 @@ goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 /** @suppress {extraRequire} */
-goog.require('ol.has');
+goog.require('ol');
+goog.require('ol.proj');
 goog.require('olgm');
 goog.require('olgm.herald.Herald');
 

--- a/src/interaction/interactiondefaults.js
+++ b/src/interaction/interactiondefaults.js
@@ -1,5 +1,6 @@
 goog.provide('olgm.interaction');
 
+goog.require('ol.interaction');
 goog.require('ol.interaction.DragPan');
 
 

--- a/src/layer/googlelayer.js
+++ b/src/layer/googlelayer.js
@@ -1,5 +1,6 @@
 goog.provide('olgm.layer.Google');
 
+goog.require('ol');
 goog.require('ol.layer.Group');
 
 

--- a/src/ol3googlemaps.js
+++ b/src/ol3googlemaps.js
@@ -1,5 +1,6 @@
 goog.provide('olgm.OLGoogleMaps');
 
+goog.require('ol');
 goog.require('olgm.Abstract');
 goog.require('olgm.herald.Layers');
 

--- a/src/olgm.js
+++ b/src/olgm.js
@@ -1,5 +1,6 @@
 goog.provide('olgm');
 
+goog.require('ol.extent');
 
 /**
  * @type {!Array.<number>}


### PR DESCRIPTION
Hi there,

This PR attempts to update ol3-google-maps to OpenLayers 4.1.1 and closure-util 1.18.0. I hope the changes looks good.

However, I'm getting some errors when trying to run the tests:
```
node tasks/test.js
/Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:186
              throw new Error('Unsatisfied dependency "' + require + '" ' +
              ^

Error: Unsatisfied dependency "ol" in script: /Users/hawk/code/ol3-google-maps/src/gm/maplabel.js
    at /Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:186:21
    at Array.forEach (native)
    at visit (/Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:183:25)
    at /Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:190:13
    at Array.forEach (native)
    at visit (/Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:183:25)
    at /Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:212:11
    at Array.forEach (native)
    at Manager.getDependencies (/Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/manager.js:205:34)
    at Server._requestListener (/Users/hawk/code/ol3-google-maps/node_modules/closure-util/lib/server.js:153:32)
```

I'd appreciate any feedback I could get on the above.

What do you think?

Håkon