### PR TITLE
Fix #158 - use utility methods to create WMS image url

### DIFF
--- a/src/olgm/uri.js
+++ b/src/olgm/uri.js
@@ -1,0 +1,28 @@
+goog.provide('olgm.uri');
+
+
+/**
+ * Shamelessly borrowed from `ol.uri.appendParams`.
+ *
+ * Appends query parameters to a URI.
+ *
+ * @param {string} uri The original URI, which may already have query data.
+ * @param {!Object} params An object where keys are URI-encoded parameter keys,
+ *     and the values are arbitrary types or arrays.
+ * @return {string} The new URI.
+ */
+olgm.uri.appendParams = function(uri, params) {
+  var keyParams = [];
+  // Skip any null or undefined parameter values
+  Object.keys(params).forEach(function(k) {
+    if (params[k] !== null && params[k] !== undefined) {
+      keyParams.push(k + '=' + encodeURIComponent(params[k]));
+    }
+  });
+  var qs = keyParams.join('&');
+  // remove any trailing ? or &
+  uri = uri.replace(/[?&]$/, '');
+  // append ? or & depending on whether uri has existing parameters
+  uri = uri.indexOf('?') === -1 ? uri + '?' : uri + '&';
+  return uri + qs;
+};


### PR DESCRIPTION
Fix the issue reported in #158.  A utility method is now used to build the url, which takes any existing `?` character within the base url into account.