### PR TITLE
Herald support to sync style changes

### DIFF
--- a/examples/concept.js
+++ b/examples/concept.js
@@ -182,6 +182,7 @@ var generateLineFeature = function() {
 };
 
 var addPointFeatures = function(len, opt_style) {
+  var features = [];
   var feature;
   for (var i = 0; i < len; i++) {
     feature = generatePointFeature();
@@ -191,11 +192,13 @@ var addPointFeatures = function(len, opt_style) {
       feature.setStyle(style);
     }
     vector.getSource().addFeature(feature);
+    features.push(feature);
   }
+  return features;
 };
 
 var addMarkerFeatures = function(len) {
-  addPointFeatures(len, {
+  var points = addPointFeatures(len, {
     image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
       anchor: [0.5, 46],
       anchorXUnits: 'fraction',
@@ -212,6 +215,15 @@ var addMarkerFeatures = function(len) {
       stroke: new ol.style.Stroke({color: '#ffffff', width: 5}),
     })
   });
+
+  setTimeout(function() {
+    var style = points[0].getStyle();
+    var text = style.getText().clone();
+    text.setText('HI');
+    style.setText(text);
+    // set the style after the feature has rendered, which tests herald
+    points[0].setStyle(style);
+  }, 1000);
 };
 
 var addCircleFeatures = function(len) {


### PR DESCRIPTION
Herald now listens to the `change` event, detects when the style has changed (ignoring additional geometry changes) and then applies the new style if necessary.

I have two minor concerns:

1. `ol.Feature` does not trigger a `change:style` event as some other `ol` objects support, it simply triggers `change`. This means we need to listen for all changes and determine if it was styles that got changed. `change` is also called whenever the geometry updates, this isn't very performant overall.

2. I had to add `goog.json`, because `goog.object.equals` does not deal with deep comparisons well and `ol.style.Style` does not offer its own equals comparator.

I think the far better solution would be to get openlayers to support telling us which property changed on the `change` event of a feature. Definitely open to suggestions.
