### PR TITLE
Fix ImageOverlay onRemove - check if this.div_ is defined

### DIFF
--- a/src/gm/imageoverlay.js
+++ b/src/gm/imageoverlay.js
@@ -134,6 +134,8 @@ olgm.gm.ImageOverlay.prototype.setZIndex = function(zIndex) {
  * @api
  */
 olgm.gm.ImageOverlay.prototype.onRemove = function() {
-  this.div_.parentNode.removeChild(this.div_);
-  this.div_ = null;
+  if (this.div_) {
+    this.div_.parentNode.removeChild(this.div_);
+    this.div_ = null;
+  }
 };


### PR DESCRIPTION
Fix for #217 in the `b0.12` branch.