### PR TITLE
Fix ImageOverlay onRemove - check if this.div_ is defined

### DIFF
--- a/src/olgm/gm/imageoverlay.js
+++ b/src/olgm/gm/imageoverlay.js
@@ -135,6 +135,8 @@ olgm.gm.ImageOverlay.prototype.setZIndex = function(zIndex) {
  * @override
  */
 olgm.gm.ImageOverlay.prototype.onRemove = function() {
-  this.div_.parentNode.removeChild(this.div_);
-  this.div_ = null;
+  if (this.div_) {
+    this.div_.parentNode.removeChild(this.div_);
+    this.div_ = null;
+  }
 };


### PR DESCRIPTION
This is the fix for the issue #217 for the master branch.