### PR TITLE
Update release instructions for code using ES modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ olGM.activate();
 
 ## Live examples
 
-See OL3-Google-Maps in action:
+See OL3-Google-Maps in action (version v0.20.0):
 
  * [Simple](http://mapgears.github.io/ol3-google-maps/examples/dist/examples/simple.html)
  * [Vector](http://mapgears.github.io/ol3-google-maps/examples/dist/examples/vector.html)
@@ -80,8 +80,9 @@ http://mapgears.github.io/ol3-google-maps/examples/
 
 ## Developing
 
-See the [developing](DEVELOPING.md) instructions if you want to contribute
-new features or patches to OL3-Google-Maps.
+See the [developing](DEVELOPING.md) instructions if you want to
+contribute new features or patches to OL3-Google-Maps or if you want
+to see the examples in action using the latest version.
 
 Note that contributions have to meet some minimum quality requirements
 in order to be included in the official package, but that's the same

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,10 +5,11 @@
 Update your repository with `git checkout master` and make sure there are no
 changes when running `git status`.
 
-### Run checks ###
+### Run linter and tests ###
 
-Type `make check` to run the linter, builder and the tests. If an error is
-raised, it needs to be fixed and committed before going to the next step.
+Type `npm run lint` to run the linter.
+
+Type `npm run test` to test the building of the JS code.
 
 ### Create a changelog ###
 
@@ -52,19 +53,13 @@ upstream):
 
 ### Create a distributable package ###
 
-Create a zip containing the compiled code using the following commands:
-
-    make dist
-    ./tasks/package.sh v0.8.0
-
-It will appear in the directory where you ran the command
+OLGM currently no longer distribute a package.
 
 ### Create the release description on GitHub ###
 
 With the tag pushed, a new release will appear on the
 [releases](https://github.com/mapgears/ol3-google-maps/releases) page. Create a
-description including the major points and the changelog. Include the package
-generated in the last step in the files attached to the release.
+description including the major points and the changelog.
 
 ### Publish to npm ###
 
@@ -73,12 +68,12 @@ send it to npm. When running this command, you need to include the version
 number, without the `v` prefix. You also need to have a npm account and be a
 contributor to the project.
 
-    rm *.zip
     ./tasks/publish.sh 0.8.0
 
-The zip file containing the compiled code is removed first.
-
 ### Update the website ###
+
+FIXME - these instructions are deprecated. In order for these pages to
+work, we would need to have a distribution package.
 
 The website should be updated with the latest compiled examples and a link to
 the packaged library.

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -74,9 +74,9 @@ main() {
   assert_clean
   checkout_tag ${1}
   assert_version_match ${1}
-  rm -rf ${BUILDS}
+  #rm -rf ${BUILDS} # todo - restore dist
   npm install
-  make dist
+  #make dist - todo - restore dist
   npm publish
 }
 


### PR DESCRIPTION
Update the instructions about how to make a release.

We no longer have a distributed package, so this is no longer included in the version.

Also, the webpage with the examples would require efforts to be updated to the latest release.  I think we would need to use a distributed package, or simply re-do the pages (I'm not sure at this point), but for now the idea is to freeze them to the v0.20.0 version and if anyone wants to do the effort of updating them a separate PR would be welcome.  We could also change how we build them entirely.

That's pretty much it for now.

@JamiesWhiteShirt Would you please tell me if the `Run linter and tests` instructions in the RELEASE .md file make sense?