### PR TITLE
Workaround bug 9015 in OpenLayers 5.3.0 - call getTileUrlFunction within context of source

### DIFF
--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -214,12 +214,12 @@ class TileSourceHerald extends SourceHerald {
       }
     }
 
-    let result = getTileUrlFunction(ol3Coords, 1, proj);
+    let result = getTileUrlFunction.call(source, ol3Coords, 1, proj);
 
     // TileJSON sources don't have their url function right away, try again
     if (result === undefined) {
       getTileUrlFunction = source.getTileUrlFunction();
-      result = getTileUrlFunction(ol3Coords, 1, proj);
+      result = getTileUrlFunction.call(source, ol3Coords, 1, proj);
     }
 
     return result;


### PR DESCRIPTION
There is a problem introduced in OpenLayers 5.3.0: https://github.com/openlayers/openlayers/issues/9015, whereby using an ol.source.TileArcGISRest, the TileSourceHerald causes an error within the TileArcGISRest tileUrlFunction because retrieving the tile url function with source.getTileUrlFunction() returns an unbounded function (it used to be bound to source by the constructor).

This workaround uses getTileUrlFunction.call(source, ...) instead.

OpenLayers itself calls source.tileUrlFunction(...) directly so doesn't have the same problem.