### PR TITLE
Handle changing object properties

### DIFF
--- a/src/olgm/herald/Herald.js
+++ b/src/olgm/herald/Herald.js
@@ -1,7 +1,6 @@
 /**
  * @module olgm/herald/Herald
  */
-import {unlistenAllByKey} from '../util.js';
 import Abstract from '../Abstract.js';
 
 /**
@@ -24,16 +23,10 @@ class Herald extends Abstract {
     super(ol3map, gmap);
 
     /**
-     * @type {Array<module:ol/events~EventsKey|Array<module:ol/events~EventsKey>>}
+     * @type {module:olgm/AbstractListener~AbstractListener|null}
      * @protected
      */
-    this.listenerKeys = [];
-
-    /**
-     * @type {Array<module:ol/events~EventsKey>}
-     * @protected
-     */
-    this.olgmListenerKeys = [];
+    this.listener = null;
   }
 
 
@@ -47,7 +40,9 @@ class Herald extends Abstract {
    * Unregister all event listeners.
    */
   deactivate() {
-    unlistenAllByKey(this.listenerKeys, this.olgmListenerKeys);
+    if (this.listener) {
+      this.listener.unlisten();
+    }
   }
 }
 export default Herald;

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -86,18 +86,6 @@ class TileSourceHerald extends SourceHerald {
       zIndex: 0
     });
 
-    cacheItem.listeners.push(
-      // Hide the google layer when the ol3 layer is invisible
-      new Listener(tileLayer.on('change:visible', () => this.handleVisibleChange_(cacheItem))),
-      new Listener(tileLayer.on('change:opacity', () => this.handleOpacityChange_(cacheItem))),
-      new PropertyListener(tileLayer, null, 'source', (source, oldSource) => {
-        if (oldSource) {
-          this.handleSourceChange_(cacheItem);
-        }
-        return new Listener(source.on('change', () => this.handleSourceChange_(cacheItem)));
-      })
-    );
-
     const tileGrid = source.getTileGrid();
     let tileSize = 256;
 
@@ -123,6 +111,18 @@ class TileSourceHerald extends SourceHerald {
       this.gmap.overlayMapTypes.push(googleTileLayer);
     }
     cacheItem.googleTileLayer = googleTileLayer;
+
+    cacheItem.listeners.push(
+      // Hide the google layer when the ol3 layer is invisible
+      new Listener(tileLayer.on('change:visible', () => this.handleVisibleChange_(cacheItem))),
+      new Listener(tileLayer.on('change:opacity', () => this.handleOpacityChange_(cacheItem))),
+      new PropertyListener(tileLayer, null, 'source', (source, oldSource) => {
+        if (oldSource) {
+          this.handleSourceChange_(cacheItem);
+        }
+        return new Listener(source.on('change', () => this.handleSourceChange_(cacheItem)));
+      })
+    );
 
     // Activate the cache item
     this.activateCacheItem_(cacheItem);

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -4,9 +4,10 @@
 import {getIntersection, getSize} from 'ol/extent.js';
 import {get} from 'ol/proj.js';
 import TileImage from 'ol/source/TileImage.js';
-import {unlistenAllByKey} from '../util.js';
 import PanesOverlay from '../gm/PanesOverlay.js';
 import SourceHerald from './Source.js';
+import Listener from '../listener/Listener.js';
+import PropertyListener from '../listener/PropertyListener.js';
 
 /**
  * @typedef {Object} LayerCache
@@ -14,7 +15,7 @@ import SourceHerald from './Source.js';
  * @property {google.maps.ImageMapType} googleTileLayer
  * @property {boolean} ignoreNextOpacityChange
  * @property {module:ol/layer/Tile} layer
- * @property {Array<module:ol/events~EventsKey|Array<module:ol/events~EventsKey>>} listenerKeys
+ * @property {Array<module:olgm/AbstractListener~AbstractListener>} listeners
  * @property {number} opacity
  * @property {number} zIndex
  */
@@ -80,10 +81,22 @@ class TileSourceHerald extends SourceHerald {
       element: null,
       ignoreNextOpacityChange: true,
       layer: tileLayer,
-      listenerKeys: [],
+      listeners: [],
       opacity: opacity,
       zIndex: 0
     });
+
+    cacheItem.listeners.push(
+      // Hide the google layer when the ol3 layer is invisible
+      new Listener(tileLayer.on('change:visible', () => this.handleVisibleChange_(cacheItem))),
+      new Listener(tileLayer.on('change:opacity', () => this.handleOpacityChange_(cacheItem))),
+      new PropertyListener(tileLayer, null, 'source', (source, oldSource) => {
+        if (oldSource) {
+          this.handleSourceChange_(cacheItem);
+        }
+        return new Listener(source.on('change', () => this.handleSourceChange_(cacheItem)));
+      })
+    );
 
     const tileGrid = source.getTileGrid();
     let tileSize = 256;
@@ -110,14 +123,6 @@ class TileSourceHerald extends SourceHerald {
       this.gmap.overlayMapTypes.push(googleTileLayer);
     }
     cacheItem.googleTileLayer = googleTileLayer;
-
-    // Hide the google layer when the ol3 layer is invisible
-    cacheItem.listenerKeys.push(tileLayer.on('change:visible',
-      () => this.handleVisibleChange_(cacheItem)));
-    cacheItem.listenerKeys.push(tileLayer.on('change:opacity',
-      () => this.handleOpacityChange_(cacheItem)));
-    cacheItem.listenerKeys.push(tileLayer.getSource().on('change',
-      () => this.handleSourceChange_(cacheItem)));
 
     // Activate the cache item
     this.activateCacheItem_(cacheItem);
@@ -239,7 +244,7 @@ class TileSourceHerald extends SourceHerald {
       this.layers_.splice(index, 1);
 
       const cacheItem = this.cache_[index];
-      unlistenAllByKey(cacheItem.listenerKeys);
+      cacheItem.listeners.forEach(listener => listener.unlisten());
 
       // Remove the layer from google maps
       const googleTileLayer = cacheItem.googleTileLayer;

--- a/src/olgm/herald/VectorFeature.js
+++ b/src/olgm/herald/VectorFeature.js
@@ -3,6 +3,7 @@
  */
 import FeatureHerald from './Feature.js';
 import Herald from './Herald.js';
+import Listener from '../listener/Listener.js';
 
 /**
  * @typedef {Object} Cache
@@ -74,9 +75,10 @@ class VectorFeatureHerald extends Herald {
     this.source_.getFeatures().forEach((feature) => this.watchFeature_(feature));
 
     // event listeners
-    const keys = this.listenerKeys;
-    keys.push(this.source_.on('addfeature', (event) => this.handleAddFeature_(event)));
-    keys.push(this.source_.on('removefeature', (event) => this.handleRemoveFeature_(event)));
+    this.listener = new Listener([
+      this.source_.on('addfeature', (event) => this.handleAddFeature_(event)),
+      this.source_.on('removefeature', (event) => this.handleRemoveFeature_(event))
+    ]);
   }
 
 

--- a/src/olgm/herald/VectorSource.js
+++ b/src/olgm/herald/VectorSource.js
@@ -83,25 +83,18 @@ class VectorSourceHerald extends SourceHerald {
       data: data,
       herald: herald,
       layer: vectorLayer,
-      listeners: [
-        new PropertyListener(this.ol3map, null, 'view', (view, oldView) => {
-          if (oldView) {
-            if (oldView.get('resolution') !== view.get('resolution')) {
-              this.handleResolutionChange_(cacheItem);
-            }
-            if (oldView.get('visible') !== view.get('visible')) {
-              this.handleVisibleChange_(cacheItem);
-            }
-          }
-
-          return new Listener([
-            view.on('change:resolution', () => this.handleResolutionChange_(cacheItem)),
-            view.on('change:visible', () => this.handleVisibleChange_(cacheItem))
-          ]);
-        })
-      ],
+      listeners: [],
       opacity: opacity
     });
+
+    cacheItem.listeners.push(
+      new PropertyListener(this.ol3map, null, 'view', (view, oldView) => {
+        return [
+          new PropertyListener(view, oldView, 'resolution', () => this.handleResolutionChange_(cacheItem)),
+          new PropertyListener(view, oldView, 'visible', () => this.handleVisibleChange_(cacheItem))
+        ];
+      })
+    );
 
     this.activateCacheItem_(cacheItem);
 
@@ -129,7 +122,6 @@ class VectorSourceHerald extends SourceHerald {
 
       // herald
       cacheItem.herald.deactivate();
-
 
       // opacity
       vectorLayer.setOpacity(cacheItem.opacity);

--- a/src/olgm/herald/VectorSource.js
+++ b/src/olgm/herald/VectorSource.js
@@ -5,7 +5,6 @@ import {createStyle} from '../gm.js';
 import SourceHerald from './Source.js';
 import VectorFeatureHerald from './VectorFeature.js';
 import PropertyListener from '../listener/PropertyListener.js';
-import Listener from '../listener/Listener.js';
 
 /**
  * @typedef {Object} LayerCache

--- a/src/olgm/herald/VectorSource.js
+++ b/src/olgm/herald/VectorSource.js
@@ -1,17 +1,18 @@
 /**
  * @module olgm/herald/VectorSource
  */
-import {unlistenAllByKey} from '../util.js';
 import {createStyle} from '../gm.js';
 import SourceHerald from './Source.js';
 import VectorFeatureHerald from './VectorFeature.js';
+import PropertyListener from '../listener/PropertyListener.js';
+import Listener from '../listener/Listener.js';
 
 /**
  * @typedef {Object} LayerCache
  * @property {google.maps.Data} data
  * @property {module:olgm/herald/VectorFeature} herald
  * @property {module:ol/layer/Vector} layer
- * @property {Array<module:ol/events~EventsKey|Array<module:ol/events~EventsKey>>} listenerKeys
+ * @property {?module:olgm/AbstractListener~AbstractListener} listeners
  * @property {number} opacity
  */
 
@@ -82,17 +83,25 @@ class VectorSourceHerald extends SourceHerald {
       data: data,
       herald: herald,
       layer: vectorLayer,
-      listenerKeys: [],
+      listeners: [
+        new PropertyListener(this.ol3map, null, 'view', (view, oldView) => {
+          if (oldView) {
+            if (oldView.get('resolution') !== view.get('resolution')) {
+              this.handleResolutionChange_(cacheItem);
+            }
+            if (oldView.get('visible') !== view.get('visible')) {
+              this.handleVisibleChange_(cacheItem);
+            }
+          }
+
+          return new Listener([
+            view.on('change:resolution', () => this.handleResolutionChange_(cacheItem)),
+            view.on('change:visible', () => this.handleVisibleChange_(cacheItem))
+          ]);
+        })
+      ],
       opacity: opacity
     });
-
-    cacheItem.listenerKeys.push(vectorLayer.on('change:visible',
-      () => this.handleVisibleChange_(cacheItem)));
-
-    const view = this.ol3map.getView();
-    cacheItem.listenerKeys.push(view.on('change:resolution',
-      () => this.handleResolutionChange_(cacheItem)));
-
 
     this.activateCacheItem_(cacheItem);
 
@@ -113,13 +122,14 @@ class VectorSourceHerald extends SourceHerald {
       this.layers_.splice(index, 1);
 
       const cacheItem = this.cache_[index];
-      unlistenAllByKey(cacheItem.listenerKeys);
+      cacheItem.listeners.forEach(listener => listener.unlisten());
 
       // data - unset
       cacheItem.data.setMap(null);
 
       // herald
       cacheItem.herald.deactivate();
+
 
       // opacity
       vectorLayer.setOpacity(cacheItem.opacity);

--- a/src/olgm/herald/View.js
+++ b/src/olgm/herald/View.js
@@ -29,8 +29,6 @@ class ViewHerald extends Herald {
      * @private
      */
     this.windowResizeTimerId_ = null;
-
-    this.viewListener = null;
   }
 
 

--- a/src/olgm/herald/View.js
+++ b/src/olgm/herald/View.js
@@ -3,8 +3,10 @@
  */
 import {transform} from 'ol/proj.js';
 import {getZoomFromResolution} from '../util.js';
-import {listen} from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import Herald from './Herald.js';
+import PropertyListener from '../listener/PropertyListener.js';
+import Listener from '../listener/Listener.js';
 
 class ViewHerald extends Herald {
   /**
@@ -27,6 +29,8 @@ class ViewHerald extends Herald {
      * @private
      */
     this.windowResizeTimerId_ = null;
+
+    this.viewListener = null;
   }
 
 
@@ -36,25 +40,30 @@ class ViewHerald extends Herald {
   activate() {
     super.activate();
 
-    const view = this.ol3map.getView();
-    const keys = this.listenerKeys;
+    this.listener = new PropertyListener(this.ol3map, null, 'view', (view, oldView) => {
+      if (oldView) {
+        this.setRotation();
+        this.setCenter();
+        this.setZoom();
+      }
 
-    // listen to center change
-    keys.push(view.on('change:center', () => this.setCenter()));
-
-    // listen to resolution change
-    keys.push(view.on('change:resolution', () => this.setZoom()));
-
-    // listen to rotation change
-    keys.push(view.on('change:rotation', () => this.setRotation()));
+      return new Listener([
+        // listen to center change
+        view.on('change:center', () => this.setCenter()),
+        // listen to resolution change
+        view.on('change:resolution', () => this.setZoom()),
+        // listen to rotation change
+        view.on('change:rotation', () => this.setRotation())
+      ]);
+    });
 
     // listen to browser window resize
-    this.olgmListenerKeys.push(listen(
+    this.windowListenerKey = listen(
       window,
       'resize',
       this.handleWindowResize_,
       this,
-      false));
+      false);
 
     // Rotate and recenter the map after it's ready
     google.maps.event.addListenerOnce(this.gmap, 'idle', () => {
@@ -65,11 +74,10 @@ class ViewHerald extends Herald {
   }
 
 
-  /**
-   * @inheritDoc
-   */
   deactivate() {
     super.deactivate();
+
+    unlistenByKey(this.windowListenerKey);
   }
 
 

--- a/src/olgm/herald/View.js
+++ b/src/olgm/herald/View.js
@@ -29,6 +29,12 @@ class ViewHerald extends Herald {
      * @private
      */
     this.windowResizeTimerId_ = null;
+
+    /**
+     * @type {?module:ol/events~EventsKey}
+     * @private
+     */
+    this.windowListenerKey_ = null;
   }
 
 
@@ -56,7 +62,7 @@ class ViewHerald extends Herald {
     });
 
     // listen to browser window resize
-    this.windowListenerKey = listen(
+    this.windowListenerKey_ = listen(
       window,
       'resize',
       this.handleWindowResize_,
@@ -75,7 +81,7 @@ class ViewHerald extends Herald {
   deactivate() {
     super.deactivate();
 
-    unlistenByKey(this.windowListenerKey);
+    unlistenByKey(this.windowListenerKey_);
   }
 
 

--- a/src/olgm/listener/AbstractListener.js
+++ b/src/olgm/listener/AbstractListener.js
@@ -1,4 +1,7 @@
 /**
+ * @module olgm/listener/AbstractListener
+ */
+/**
  * Interface for things that have listened to something that can be unlistened to.
  */
 class AbstractListener {

--- a/src/olgm/listener/AbstractListener.js
+++ b/src/olgm/listener/AbstractListener.js
@@ -1,0 +1,13 @@
+/**
+ * Interface for things that have listened to something that can be unlistened to.
+ */
+class AbstractListener {
+  /**
+   * Unlisten to what the listener has listened to.
+   */
+  unlisten() {
+    throw new TypeError('not implemented');
+  }
+}
+
+export default AbstractListener;

--- a/src/olgm/listener/Listener.js
+++ b/src/olgm/listener/Listener.js
@@ -1,0 +1,22 @@
+import AbstractListener from './AbstractListener';
+import {unByKey} from 'ol/Observable';
+
+class Listener extends AbstractListener {
+  /**
+   * Listener for OL events.
+   * @param {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} listenerKey OL events key
+   */
+  constructor(listenerKey) {
+    super();
+    this.listenerKey = listenerKey;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  unlisten() {
+    unByKey(this.listenerKey);
+  }
+}
+
+export default Listener;

--- a/src/olgm/listener/Listener.js
+++ b/src/olgm/listener/Listener.js
@@ -1,3 +1,6 @@
+/**
+ * @module olgm/listener/Listener
+ */
 import AbstractListener from './AbstractListener';
 import {unByKey} from 'ol/Observable';
 
@@ -8,14 +11,19 @@ class Listener extends AbstractListener {
    */
   constructor(listenerKey) {
     super();
-    this.listenerKey = listenerKey;
+
+    /**
+     * @type {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>}
+     * @private
+     */
+    this.listenerKey_ = listenerKey;
   }
 
   /**
    * @inheritdoc
    */
   unlisten() {
-    unByKey(this.listenerKey);
+    unByKey(this.listenerKey_);
   }
 }
 

--- a/src/olgm/listener/PropertyListener.js
+++ b/src/olgm/listener/PropertyListener.js
@@ -10,7 +10,7 @@ class PropertyListener extends AbstractListener {
    * @param {function} listen Takes the current and previous property value as arguments.
    * Called on initialization and when the property value changes.
    * On initialization, the previous property value will be taken from the old target, if any.
-   * Can return an AbstractListener which will be unlistened when the property value changes.
+   * Can return an AbstractListener or an array of AbstractListeners which will be unlistened when the property value changes.
    */
   constructor(target, oldTarget, key, listen) {
     super();
@@ -30,7 +30,11 @@ class PropertyListener extends AbstractListener {
    */
   unlisten() {
     if (this.innerListener) {
-      this.innerListener.unlisten();
+      if (Array.isArray(this.innerListener)) {
+        this.innerListener.forEach(listener => listener.unlisten());
+      } else {
+        this.innerListener.unlisten();
+      }
     }
     unByKey(this.targetListenerKey);
   }

--- a/src/olgm/listener/PropertyListener.js
+++ b/src/olgm/listener/PropertyListener.js
@@ -1,0 +1,39 @@
+import AbstractListener from './AbstractListener';
+import {unByKey} from 'ol/Observable';
+
+class PropertyListener extends AbstractListener {
+  /**
+   * Listener for OL object properties. Has utilities for listening on the property value.
+   * @param {module:ol/Object~BaseObject} target Object with a property
+   * @param {?module:ol/Object~BaseObject} oldTarget The previous object with a property
+   * @param {string} key Property key
+   * @param {function} listen Takes the current and previous property value as arguments.
+   * Called on initialization and when the property value changes.
+   * On initialization, the previous property value will be taken from the old target, if any.
+   * Can return an AbstractListener which will be unlistened when the property value changes.
+   */
+  constructor(target, oldTarget, key, listen) {
+    super();
+
+    this.targetListenerKey = target.on('change:' + key, e => {
+      if (this.innerListener) {
+        this.innerListener.unlisten();
+      }
+      this.innerListener = listen(e.target.get(e.key), e.oldValue);
+    });
+
+    this.innerListener = listen(target.get(key), oldTarget && oldTarget.get(key));
+  }
+
+  /**
+   * @inheritdoc
+   */
+  unlisten() {
+    if (this.innerListener) {
+      this.innerListener.unlisten();
+    }
+    unByKey(this.targetListenerKey);
+  }
+}
+
+export default PropertyListener;

--- a/src/olgm/listener/PropertyListener.js
+++ b/src/olgm/listener/PropertyListener.js
@@ -1,7 +1,6 @@
-import AbstractListener from './AbstractListener';
-import {unByKey} from 'ol/Observable';
+import Listener from './Listener';
 
-class PropertyListener extends AbstractListener {
+class PropertyListener extends Listener {
   /**
    * Listener for OL object properties. Has utilities for listening on the property value.
    * @param {module:ol/Object~BaseObject} target Object with a property
@@ -13,14 +12,12 @@ class PropertyListener extends AbstractListener {
    * Can return an AbstractListener or an array of AbstractListeners which will be unlistened when the property value changes.
    */
   constructor(target, oldTarget, key, listen) {
-    super();
-
-    this.targetListenerKey = target.on('change:' + key, e => {
+    super(target.on('change:' + key, e => {
       if (this.innerListener) {
         this.innerListener.unlisten();
       }
       this.innerListener = listen(e.target.get(e.key), e.oldValue);
-    });
+    }));
 
     this.innerListener = listen(target.get(key), oldTarget && oldTarget.get(key));
   }
@@ -36,7 +33,7 @@ class PropertyListener extends AbstractListener {
         this.innerListener.unlisten();
       }
     }
-    unByKey(this.targetListenerKey);
+    super.unlisten();
   }
 }
 

--- a/src/olgm/listener/PropertyListener.js
+++ b/src/olgm/listener/PropertyListener.js
@@ -1,10 +1,13 @@
+/**
+ * @module olgm/listener/PropertyListener
+ */
 import Listener from './Listener';
 
 class PropertyListener extends Listener {
   /**
    * Listener for OL object properties. Has utilities for listening on the property value.
    * @param {module:ol/Object~BaseObject} target Object with a property
-   * @param {?module:ol/Object~BaseObject} oldTarget The previous object with a property
+   * @param {module:ol/Object~BaseObject=} oldTarget The previous object with a property
    * @param {string} key Property key
    * @param {function} listen Takes the current and previous property value as arguments.
    * Called on initialization and when the property value changes.
@@ -16,21 +19,25 @@ class PropertyListener extends Listener {
       if (this.innerListener) {
         this.innerListener.unlisten();
       }
-      this.innerListener = listen(e.target.get(e.key), e.oldValue);
+      this.innerListener_ = listen(e.target.get(e.key), e.oldValue);
     }));
 
-    this.innerListener = listen(target.get(key), oldTarget && oldTarget.get(key));
+    /**
+     * @type {?module:olgm/AbstractListener~AbstractListener|Array<module:olgm/AbstractListener~AbstractListener>}
+     * @private
+     */
+    this.innerListener_ = listen(target.get(key), oldTarget && oldTarget.get(key));
   }
 
   /**
    * @inheritdoc
    */
   unlisten() {
-    if (this.innerListener) {
-      if (Array.isArray(this.innerListener)) {
+    if (this.innerListener_) {
+      if (Array.isArray(this.innerListener_)) {
         this.innerListener.forEach(listener => listener.unlisten());
       } else {
-        this.innerListener.unlisten();
+        this.innerListener_.unlisten();
       }
     }
     super.unlisten();

--- a/src/olgm/util.js
+++ b/src/olgm/util.js
@@ -2,13 +2,11 @@
  * @module olgm/util
  */
 import Feature from 'ol/Feature.js';
-import {unByKey} from 'ol/Observable.js';
 import {getCenter} from 'ol/extent.js';
 import Point from 'ol/geom/Point.js';
 import Polygon from 'ol/geom/Polygon.js';
 import Vector from 'ol/layer/Vector.js';
 import Style from 'ol/style/Style.js';
-import {unlistenByKey} from './events.js';
 
 /**
  * @type {!Array<number>}
@@ -208,21 +206,6 @@ export function parseRGBA(rgbaString) {
  */
 export function stringStartsWith(string, needle) {
   return (string.indexOf(needle) === 0);
-}
-
-
-/**
- * @param {Array<module:ol/events~EventsKey|Array<module:ol/events~EventsKey>>} listenerKeys listener
- * keys
- * @param {Array<module:ol/events~EventsKey>=} opt_olgmListenerKeys olgm listener keys
- */
-export function unlistenAllByKey(listenerKeys, opt_olgmListenerKeys) {
-  listenerKeys.forEach(unByKey);
-  listenerKeys.length = 0;
-  if (opt_olgmListenerKeys) {
-    opt_olgmListenerKeys.forEach(unlistenByKey);
-    opt_olgmListenerKeys.length = 0;
-  }
 }
 
 /**

--- a/test/spec/olgm/herald/Layers.test.js
+++ b/test/spec/olgm/herald/Layers.test.js
@@ -26,17 +26,4 @@ describe('olgm.herald.Layers', function() {
       expect(ol3map).to.equal(originalOl3map);
     });
   });
-
-  describe('#activate()', function() {
-    it('adds listener keys for layers added and removed', function() {
-      const layersHerald = new Layers(
-        originalOl3map, originalGmap, watchVector);
-      const listenerKeys = layersHerald.listenerKeys;
-      const expectedNbListenerKeys = listenerKeys.length + 2;
-
-      layersHerald.activate();
-
-      expect(listenerKeys.length).to.equal(expectedNbListenerKeys);
-    });
-  });
 });


### PR DESCRIPTION
This resolves #176.

OLGM assumes some properties remain unchanged. These assumptions can be harmful for certain use cases. This PR attempts to resolve some of these by ensuring that dependent properties are observed.

I believe the Herald `listenerKeys` pattern doesn't work well enough. You can see the pattern fail in the Feature herald, and there are more cases where this kind of handling would be necessary.

I have replaced this pattern with an `AbstractListener` interface which allows you to compose listeners. A good example of its usage is in the Layers herald. It can now easily handle [`Map#setLayerGroup`](https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html#setLayerGroup) or [`LayerGroup#setLayers`](https://openlayers.org/en/latest/apidoc/module-ol_layer_Group-LayerGroup.html#setLayers) which would previously break the map:

```javascript
this.listener = new PropertyListener(this.ol3map, null, 'layergroup', (layerGroup, oldLayerGroup) => {
  return new PropertyListener(layerGroup, oldLayerGroup, 'layers', (layers, oldLayers) => {
    if (oldLayers) {
      oldLayers.forEach(layer => this.unwatchLayer_(layer));
    }
    layers.forEach(layer => this.watchLayer_(layer));
    
    return new Listener([
      // watch existing layers
      layers.on('add', event => this.handleLayersAdd_(event)),
      layers.on('remove', event => this.handleLayersRemove_(event))
    ]);
  });
});
```

Unfortunately, there are still a few issues left. It should be possible to use the new patterns to resolve those.