### PR TITLE
Fix resize when switching to Google layer from OSM

### DIFF
--- a/src/olgm/herald/Layers.js
+++ b/src/olgm/herald/Layers.js
@@ -422,6 +422,9 @@ class LayersHerald extends Herald {
       this);
 
     if (found) {
+      // activate before changing mapTypeId/styles
+      this.activateGoogleMaps_();
+
       // set mapTypeId
       this.gmap.setMapTypeId(found.getMapTypeId());
       // set styles
@@ -431,9 +434,6 @@ class LayersHerald extends Herald {
       } else {
         this.gmap.setOptions({'styles': null});
       }
-
-      // activate
-      this.activateGoogleMaps_();
     } else {
       // deactivate
       this.deactivateGoogleMaps_();


### PR DESCRIPTION
Fixes issue where Google map appears as a small square when setting OSM visible: false and switching from OSM to Google if using multiple Google layers with different mapTypeId's. Fixes #245.
