### PR TITLE
Allow individual layer to be excluded from layer herald

### DIFF
--- a/src/olgm/herald/ImageWMSSource.js
+++ b/src/olgm/herald/ImageWMSSource.js
@@ -58,6 +58,11 @@ class ImageWMSSourceHerald extends SorceHerald {
       return;
     }
 
+    // If olgmWatch property is false then render using OL instead
+    if (imageLayer.get('olgmWatch') === false) {
+      return;
+    }
+
     this.layers_.push(imageLayer);
 
     // opacity

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -72,6 +72,11 @@ class TileSourceHerald extends SourceHerald {
       return;
     }
 
+    // If olgmWatch property is false then render using OL instead
+    if (tileLayer.get('olgmWatch') === false) {
+      return;
+    }
+
     this.layers_.push(tileLayer);
 
     // opacity

--- a/src/olgm/herald/VectorSource.js
+++ b/src/olgm/herald/VectorSource.js
@@ -58,6 +58,11 @@ class VectorSourceHerald extends SourceHerald {
       return;
     }
 
+    // If olgmWatch property is false then render using OL instead
+    if (vectorLayer.get('olgmWatch') === false) {
+      return;
+    }
+
     this.layers_.push(vectorLayer);
 
     // Data


### PR DESCRIPTION
Closes #247 

If olgmWatch: false is added to a layer's properties it will be rendered using OL over the top of Google map instead of translated into a Google layer. This works for WMS, Tile and Vector layers.

In most cases this setting is not desired and will result in some artifacts during zoom. It is most useful when implementing advanced styling options of OL for Vector layers.

Usage:
```es6
const vector = new VectorLayer({
  source: source,
  olgmWatch: false
});
```