### PR TITLE
Fix fractionnal zoom levels calculation to match with OpenLayers

### DIFF
--- a/src/olgm/herald/View.js
+++ b/src/olgm/herald/View.js
@@ -170,7 +170,7 @@ class ViewHerald extends Herald {
   setZoom() {
     const resolution = this.ol3map.getView().getResolution();
     if (typeof resolution === 'number') {
-      const zoom = getZoomFromResolution(resolution);
+      const zoom = getZoomFromResolution(resolution, this.ol3map.getView().getMinZoom());
       this.gmap.setZoom(zoom);
     }
   }

--- a/src/olgm/util.js
+++ b/src/olgm/util.js
@@ -142,38 +142,12 @@ export function getStyleOf(object) {
 
 /**
  * @param {number} resolution the resolution to get the zoom from
+ * @param {number} minZoom the minimum zoom value (normally 0)
  * @return {number} the zoom from the resolution, which can be fractional
  */
-export function getZoomFromResolution(resolution) {
-
-  const resolutions = RESOLUTIONS;
-  let zoom;
-
-  let lowZoom = 0;
-  let highZoom = resolutions.length - 1;
-  let highRes = resolutions[lowZoom];
-  let lowRes = resolutions[highZoom];
-  let res;
-  for (let i = 0, len = resolutions.length; i < len; ++i) {
-    res = resolutions[i];
-    if (res >= resolution) {
-      highRes = res;
-      lowZoom = i;
-    }
-    if (res <= resolution) {
-      lowRes = res;
-      highZoom = i;
-      break;
-    }
-  }
-  const dRes = highRes - lowRes;
-  if (dRes > 0) {
-    zoom = lowZoom + ((highRes - resolution) / dRes);
-  } else {
-    zoom = lowZoom;
-  }
-
-  return Math.round(zoom * 1000) / 1000;
+export function getZoomFromResolution(resolution, minZoom) {
+  minZoom = minZoom || 0;
+  return minZoom + Math.log(RESOLUTIONS[0] / resolution) / Math.log(2);
 }
 
 


### PR DESCRIPTION
The current implementation of the View Herald tracks zoom changes by converting from the view resolution to an actual zoom level. This is done by doing a linear interpolation between the two closest non-fractional zoom levels. As long as non-fractional zoom levels are used this is OK since the interpolation is not really used. However for fractional zoom levels, the result of the interpolation does not correspond to the actual zoom level used as the source (in the OL map). This is causing features to appear at different places in the Google Map compared to the OpenLayers one since it does not use the same zoom level.

The fix is to use the same logarithm-based formula (as used in OpenLayers) to convert from a resolution to a zoom level. After this change the content of both maps align perfectly at fractional zoom levels.