### PR TITLE
Track changes made to feature style

### DIFF
--- a/examples/concept.js
+++ b/examples/concept.js
@@ -123,7 +123,7 @@ function handleMoveEvent(evt) {
                   src: 'data/icon.png'
                 })
               })
-            )
+            );
           }
         }
       }

--- a/examples/concept.js
+++ b/examples/concept.js
@@ -108,6 +108,26 @@ function handleMoveEvent(evt) {
     const features = map.getFeaturesAtPixel(evt.pixel);
     const element = evt.map.getTargetElement();
     if (features) {
+      const style = features[0].getStyle();
+      if (style) {
+        const image = style.getImage();
+        if (image && image.getSrc) {
+          if (image.getSrc() == 'data/icon.png') {
+            features[0].setStyle(
+              new Style({
+                image: new Icon({
+                  anchor: [0.5, 46],
+                  anchorXUnits: 'fraction',
+                  anchorYUnits: 'pixels',
+                  opacity: 0.75,
+                  src: 'data/icon.png'
+                })
+              })
+            )
+          }
+        }
+      }
+
       if (element.style.cursor != this.cursor_) {
         this.previousCursor_ = element.style.cursor;
         element.style.cursor = this.cursor_;

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -90,8 +90,6 @@ class FeatureHerald extends Herald {
   activate() {
     super.activate();
 
-    const geometry = this.getGeometry_();
-
     // create gmap feature
     this.gmapFeature_ = createFeature(this.feature_);
 
@@ -223,12 +221,12 @@ class FeatureHerald extends Herald {
 
     this.data_.overrideStyle(this.gmapFeature_, gmStyle);
 
-    var prevMarker = this.marker_;
-    var prevLabel = this.label_;
+    let prevMarker = this.marker_;
+    let prevLabel = this.label_;
 
     const style = getStyleOf(this.feature_);
     if (style) {
-      let latLng = createLatLng(getCenterOf(this.getGeometry_()));
+      const latLng = createLatLng(getCenterOf(this.getGeometry_()));
 
       const zIndex = style.getZIndex();
       const index = zIndex !== undefined ? zIndex : this.index_;

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -32,6 +32,12 @@ class FeatureHerald extends Herald {
     this.feature_ = options.feature;
 
     /**
+     * @type {module:olgm/AbstractListener~AbstractListener|null}
+     * @protected
+     */
+    this.featureListener_ = null;
+
+    /**
      * @type {!google.maps.Data}
      * @private
      */
@@ -93,39 +99,9 @@ class FeatureHerald extends Herald {
       this.data_.add(this.gmapFeature_);
     }
 
-    // override style if a style is defined at the feature level
-    const gmStyle = createStyle(
-      this.feature_, this.mapIconOptions_, this.index_);
-    if (gmStyle) {
-      this.data_.overrideStyle(this.gmapFeature_, gmStyle);
-    }
+    this.updateStyle_();
 
-    // if the feature has text style, add a map label to gmap
-    const latLng = createLatLng(getCenterOf(geometry));
-    const style = getStyleOf(this.feature_);
-
-    if (style) {
-      const zIndex = style.getZIndex();
-      const index = zIndex !== undefined ? zIndex : this.index_;
-
-      const image = style.getImage();
-      const useCanvas = this.mapIconOptions_.useCanvas !== undefined ?
-        this.mapIconOptions_.useCanvas : false;
-      if (image && image instanceof Icon && useCanvas) {
-        this.marker_ = createMapIcon(image, latLng, index);
-        if (this.visible_) {
-          this.marker_.setMap(this.gmap);
-        }
-      }
-
-      const text = style.getText();
-      if (text) {
-        this.label_ = createLabel(text, latLng, index);
-        if (this.visible_) {
-          this.label_.setMap(this.gmap);
-        }
-      }
-    }
+    this.featureListener_ = new Listener(this.feature_.on('change', () => this.handleFeatureChange_()));
 
     this.listener = new PropertyListener(this.feature_, null, 'geometry', (geometry, oldGeometry) => {
       if (oldGeometry) {
@@ -140,6 +116,9 @@ class FeatureHerald extends Herald {
    * @inheritDoc
    */
   deactivate() {
+    if (this.featureListener_) {
+      this.featureListener_.unlisten();
+    }
 
     // remove gmap feature
     this.data_.remove(this.gmapFeature_);
@@ -223,6 +202,61 @@ class FeatureHerald extends Herald {
     if (this.marker_) {
       latLng = createLatLng(getCenterOf(geometry));
       this.marker_.set('position', latLng);
+    }
+  }
+
+  /**
+   * @private
+   */
+  handleFeatureChange_() {
+    this.updateStyle_();
+  }
+
+  /**
+   * @private
+   */
+  updateStyle_() {
+
+    // override style if a style is defined at the feature level
+    const gmStyle = createStyle(
+      this.feature_, this.mapIconOptions_, this.index_);
+
+    this.data_.overrideStyle(this.gmapFeature_, gmStyle);
+
+    var prevMarker = this.marker_;
+    var prevLabel = this.label_;
+
+    const style = getStyleOf(this.feature_);
+    if (style) {
+      let latLng = createLatLng(getCenterOf(this.getGeometry_()));
+
+      const zIndex = style.getZIndex();
+      const index = zIndex !== undefined ? zIndex : this.index_;
+
+      const image = style.getImage();
+      const useCanvas = this.mapIconOptions_.useCanvas !== undefined ?
+        this.mapIconOptions_.useCanvas : false;
+      if (image && image instanceof Icon && useCanvas) {
+        this.marker_ = createMapIcon(image, latLng, index);
+        if (this.visible_) {
+          this.marker_.setMap(this.gmap);
+        }
+      }
+
+      const text = style.getText();
+      if (text) {
+        this.label_ = createLabel(text, latLng, index);
+        if (this.visible_) {
+          this.label_.setMap(this.gmap);
+        }
+      }
+    }
+
+    if (prevMarker) {
+      prevMarker.setMap(null);
+    }
+    if (prevLabel) {
+      prevLabel.setMap(null);
     }
   }
 }

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -221,8 +221,8 @@ class FeatureHerald extends Herald {
 
     this.data_.overrideStyle(this.gmapFeature_, gmStyle);
 
-    let prevMarker = this.marker_;
-    let prevLabel = this.label_;
+    const prevMarker = this.marker_;
+    const prevLabel = this.label_;
 
     const style = getStyleOf(this.feature_);
     if (style) {


### PR DESCRIPTION
Track updates to feature styles during the lifetime of a feature. Right now the olgm library only tracks the style at the creation time of a feature. Any update to a feature style is not reflected by the feature herald later on. The goal of this PR is to add this capability. Note that since OpenLayers does not explicitly send change events for styles, we have to rely on the generic change event at the feature level.