### PR TITLE
Create map icon/label on specific Google Maps pane

### DIFF
--- a/examples/concept.js
+++ b/examples/concept.js
@@ -217,7 +217,7 @@ const generateLineFeature = function() {
   );
 };
 
-const addPointFeatures = function(len, opt_style, pane) {
+const addPointFeatures = function(len, opt_style, opt_pane) {
   let feature;
   for (let i = 0; i < len; i++) {
     feature = generatePointFeature();
@@ -226,12 +226,12 @@ const addPointFeatures = function(len, opt_style, pane) {
       style.setZIndex(Math.floor(Math.random() * 1000));
       feature.setStyle(style);
     }
-    feature.usePane = pane;
+    feature.set('olgm_pane', opt_pane);
     vector.getSource().addFeature(feature);
   }
 };
 
-const addMarkerFeatures = function(len, pane) {
+const addMarkerFeatures = function (len, opt_pane) {
   addPointFeatures(len, {
     image: new Icon(/** @type {olx.style.IconOptions} */ ({
       anchor: [0.5, 46],
@@ -248,7 +248,7 @@ const addMarkerFeatures = function(len, pane) {
       fill: new Fill({color: 'black'}),
       stroke: new Stroke({color: '#ffffff', width: 5})
     })
-  }, pane);
+  }, opt_pane);
 };
 
 const addCircleFeatures = function(len) {

--- a/examples/concept.js
+++ b/examples/concept.js
@@ -228,7 +228,7 @@ const addPointFeatures = function(len, opt_style, pane) {
     }
     feature.usePane = pane;
     vector.getSource().addFeature(feature);
-   }
+  }
 };
 
 const addMarkerFeatures = function(len, pane) {

--- a/examples/concept.js
+++ b/examples/concept.js
@@ -217,7 +217,7 @@ const generateLineFeature = function() {
   );
 };
 
-const addPointFeatures = function(len, opt_style) {
+const addPointFeatures = function(len, opt_style, pane) {
   let feature;
   for (let i = 0; i < len; i++) {
     feature = generatePointFeature();
@@ -226,11 +226,12 @@ const addPointFeatures = function(len, opt_style) {
       style.setZIndex(Math.floor(Math.random() * 1000));
       feature.setStyle(style);
     }
+    feature.usePane = pane;
     vector.getSource().addFeature(feature);
-  }
+   }
 };
 
-const addMarkerFeatures = function(len) {
+const addMarkerFeatures = function(len, pane) {
   addPointFeatures(len, {
     image: new Icon(/** @type {olx.style.IconOptions} */ ({
       anchor: [0.5, 46],
@@ -247,7 +248,7 @@ const addMarkerFeatures = function(len) {
       fill: new Fill({color: 'black'}),
       stroke: new Stroke({color: '#ffffff', width: 5})
     })
-  });
+  }, pane);
 };
 
 const addCircleFeatures = function(len) {
@@ -286,7 +287,7 @@ addPointFeatures(3, {
     stroke: new Stroke({color: 'white', width: 3})
   })
 });
-addMarkerFeatures(3);
+addMarkerFeatures(3, 'overlayLayer');
 addCircleFeatures(3);
 addLineFeatures(1);
 // line with custom style

--- a/examples/concept.js
+++ b/examples/concept.js
@@ -231,7 +231,7 @@ const addPointFeatures = function(len, opt_style, opt_pane) {
   }
 };
 
-const addMarkerFeatures = function (len, opt_pane) {
+const addMarkerFeatures = function(len, opt_pane) {
   addPointFeatures(len, {
     image: new Icon(/** @type {olx.style.IconOptions} */ ({
       anchor: [0.5, 46],

--- a/src/olgm/gm.js
+++ b/src/olgm/gm.js
@@ -403,15 +403,15 @@ export function createStyleInternal(style, mapIconOptions, opt_index) {
  * @param {module:ol/style/Text} textStyle style for the text
  * @param {google.maps.LatLng} latLng position of the label
  * @param {number} index index for the label
- * @param {string} pane name of Google Maps pane to use (defaults to 'markerLayer' if not specified)
+ * @param {string=} opt_pane name of Google Maps pane to use (defaults to 'markerLayer' if not specified)
  * @return {module:olgm/gm/MapLabel} map label
  */
-export function createLabel(textStyle, latLng, index, pane) {
+export function createLabel(textStyle, latLng, index, opt_pane) {
 
   const labelOptions = {
     align: 'center',
     position: latLng,
-    pane: pane,
+    olgm_pane: opt_pane,
     zIndex: index * 2 + 1
   };
 
@@ -475,15 +475,15 @@ export function createLabel(textStyle, latLng, index, pane) {
  * @param {module:ol/style/Icon} iconStyle style for the icon
  * @param {google.maps.LatLng} latLng position of the label
  * @param {number} index index for the label
- * @param {string} pane name of Google Maps pane to use (defaults to 'markerLayer' if not specified)
+ * @param {string=} opt_pane name of Google Maps pane to use (defaults to 'markerLayer' if not specified)
  * @return {module:olgm/gm/MapIcon} map icon
  */
-export function createMapIcon(iconStyle, latLng, index, pane) {
+export function createMapIcon(iconStyle, latLng, index, opt_pane) {
 
   const iconOptions = {
     align: 'center',
     position: latLng,
-    pane: pane,
+    olgm_pane: opt_pane,
     zIndex: index * 2 + 1
   };
 

--- a/src/olgm/gm.js
+++ b/src/olgm/gm.js
@@ -405,11 +405,12 @@ export function createStyleInternal(style, mapIconOptions, opt_index) {
  * @param {number} index index for the label
  * @return {module:olgm/gm/MapLabel} map label
  */
-export function createLabel(textStyle, latLng, index) {
+export function createLabel(textStyle, latLng, index, pane) {
 
   const labelOptions = {
     align: 'center',
     position: latLng,
+    pane: pane,
     zIndex: index * 2 + 1
   };
 
@@ -475,11 +476,12 @@ export function createLabel(textStyle, latLng, index) {
  * @param {number} index index for the label
  * @return {module:olgm/gm/MapIcon} map icon
  */
-export function createMapIcon(iconStyle, latLng, index) {
+export function createMapIcon(iconStyle, latLng, index, pane) {
 
   const iconOptions = {
     align: 'center',
     position: latLng,
+    pane: pane,
     zIndex: index * 2 + 1
   };
 

--- a/src/olgm/gm.js
+++ b/src/olgm/gm.js
@@ -403,6 +403,7 @@ export function createStyleInternal(style, mapIconOptions, opt_index) {
  * @param {module:ol/style/Text} textStyle style for the text
  * @param {google.maps.LatLng} latLng position of the label
  * @param {number} index index for the label
+ * @param {string} pane name of Google Maps pane to use (defaults to 'markerLayer' if not specified)
  * @return {module:olgm/gm/MapLabel} map label
  */
 export function createLabel(textStyle, latLng, index, pane) {
@@ -474,6 +475,7 @@ export function createLabel(textStyle, latLng, index, pane) {
  * @param {module:ol/style/Icon} iconStyle style for the icon
  * @param {google.maps.LatLng} latLng position of the label
  * @param {number} index index for the label
+ * @param {string} pane name of Google Maps pane to use (defaults to 'markerLayer' if not specified)
  * @return {module:olgm/gm/MapIcon} map icon
  */
 export function createMapIcon(iconStyle, latLng, index, pane) {

--- a/src/olgm/gm/MapIcon.js
+++ b/src/olgm/gm/MapIcon.js
@@ -112,7 +112,15 @@ class MapIcon extends MapElement {
 
     const panes = this.getPanes();
     if (panes) {
-      panes.markerLayer.appendChild(canvas);
+      let pane = this.get('pane');
+      if (pane) {
+        pane = panes[pane];
+      }
+      else {
+        pane = panes.markerLayer;
+      }
+
+      pane.appendChild(canvas);
     }
   }
 }

--- a/src/olgm/gm/MapIcon.js
+++ b/src/olgm/gm/MapIcon.js
@@ -112,10 +112,11 @@ class MapIcon extends MapElement {
 
     const panes = this.getPanes();
     if (panes) {
-      let pane = this.get('pane');
+      let pane = this.get('olgm_pane');
       if (pane) {
         pane = panes[pane];
-      } else {
+      }
+      if (!pane) {
         pane = panes.markerLayer;
       }
 

--- a/src/olgm/gm/MapIcon.js
+++ b/src/olgm/gm/MapIcon.js
@@ -115,8 +115,7 @@ class MapIcon extends MapElement {
       let pane = this.get('pane');
       if (pane) {
         pane = panes[pane];
-      }
-      else {
+      } else {
         pane = panes.markerLayer;
       }
 

--- a/src/olgm/gm/MapLabel.js
+++ b/src/olgm/gm/MapLabel.js
@@ -153,8 +153,7 @@ class MapLabel extends MapElement {
       let pane = this.get('pane');
       if (pane) {
         pane = panes[pane];
-      }
-      else {
+      } else {
         pane = panes.markerLayer;
       }
 

--- a/src/olgm/gm/MapLabel.js
+++ b/src/olgm/gm/MapLabel.js
@@ -150,7 +150,15 @@ class MapLabel extends MapElement {
 
     const panes = this.getPanes();
     if (panes) {
-      panes.markerLayer.appendChild(canvas);
+      let pane = this.get('pane');
+      if (pane) {
+        pane = panes[pane];
+      }
+      else {
+        pane = panes.markerLayer;
+      }
+
+      pane.appendChild(canvas);
     }
   }
 }

--- a/src/olgm/gm/MapLabel.js
+++ b/src/olgm/gm/MapLabel.js
@@ -150,10 +150,11 @@ class MapLabel extends MapElement {
 
     const panes = this.getPanes();
     if (panes) {
-      let pane = this.get('pane');
+      let pane = this.get('olgm_pane');
       if (pane) {
         pane = panes[pane];
-      } else {
+      }
+      if (!pane) {
         pane = panes.markerLayer;
       }
 

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -216,8 +216,10 @@ class FeatureHerald extends Herald {
   updateStyle_() {
 
     // override style if a style is defined at the feature level
+    const mapIconOptions = { useCanvas: this.feature_.useCanvas || this.mapIconOptions_.useCanvas };
+
     const gmStyle = createStyle(
-      this.feature_, this.mapIconOptions_, this.index_);
+      this.feature_, mapIconOptions, this.index_);
 
     this.data_.overrideStyle(this.gmapFeature_, gmStyle);
 
@@ -232,10 +234,8 @@ class FeatureHerald extends Herald {
       const index = zIndex !== undefined ? zIndex : this.index_;
 
       const image = style.getImage();
-      const useCanvas = this.mapIconOptions_.useCanvas !== undefined ?
-        this.mapIconOptions_.useCanvas : false;
-      if (image && image instanceof Icon && useCanvas) {
-        this.marker_ = createMapIcon(image, latLng, index);
+      if (image && image instanceof Icon && mapIconOptions.useCanvas) {
+        this.marker_ = createMapIcon(image, latLng, index, this.feature_.usePane);
         if (this.visible_) {
           this.marker_.setMap(this.gmap);
         }
@@ -243,7 +243,7 @@ class FeatureHerald extends Herald {
 
       const text = style.getText();
       if (text) {
-        this.label_ = createLabel(text, latLng, index);
+        this.label_ = createLabel(text, latLng, index, this.feature_.usePane);
         if (this.visible_) {
           this.label_.setMap(this.gmap);
         }

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -216,7 +216,7 @@ class FeatureHerald extends Herald {
   updateStyle_() {
 
     // override style if a style is defined at the feature level
-    const mapIconOptions = { useCanvas: this.feature_.useCanvas || this.mapIconOptions_.useCanvas };
+    const mapIconOptions = {useCanvas: this.feature_.useCanvas || this.mapIconOptions_.useCanvas};
 
     const gmStyle = createStyle(
       this.feature_, mapIconOptions, this.index_);

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -235,7 +235,7 @@ class FeatureHerald extends Herald {
 
       const image = style.getImage();
       if (image && image instanceof Icon && mapIconOptions.useCanvas) {
-        this.marker_ = createMapIcon(image, latLng, index, this.feature_.usePane);
+        this.marker_ = createMapIcon(image, latLng, index, this.feature_.get('olgm_pane'));
         if (this.visible_) {
           this.marker_.setMap(this.gmap);
         }
@@ -243,7 +243,7 @@ class FeatureHerald extends Herald {
 
       const text = style.getText();
       if (text) {
-        this.label_ = createLabel(text, latLng, index, this.feature_.usePane);
+        this.label_ = createLabel(text, latLng, index, this.feature_.get('olgm_pane'));
         if (this.visible_) {
           this.label_.setMap(this.gmap);
         }


### PR DESCRIPTION
Provide the ability to specify on which Google Maps pane a map icon/label should be created. Currently, ol3-google-maps always use the markerLayer pane for these. The goal of this change is to provide the ability to specify the other panes optionally.

The concept example has been modified to demonstrate how we can specify the pane to use.

Google Maps panes are in the following rendering order (top-most to bottom-most):

floatPane
overlayMouseTarget
markerLayer
overlayLayer
mapPane

To see the effect of specifying a pane for a marker, the three green 'hi' icons are now created to reside in the overlayLayer pane. Dragging them across the '42' icons will now show them fully beneath these icons while they would appear on top of the '42' blue circles if no pane was specified.