### PR TITLE
Add link to olgm+webpack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ olGM.activate();
 
 ## Live examples
 
+See the following example for more detail on bundling OL3-Google-Maps with your application:
+
+ * Using [Webpack](https://github.com/geopamplona/olgm-webpack)
+ 
 See OL3-Google-Maps in action (version v0.20.0):
 
  * [Simple](http://mapgears.github.io/ol3-google-maps/examples/dist/examples/simple.html)


### PR DESCRIPTION
There are enough people looking for a simple and clear example of integrating OLGM with Webpack with their application. In this case I created a repository with this integration using webpack. 
Developers could be used as a basis for development and to test that the library works.
It can be useful to improve the examples with the new version of OLGM and google api.