### PR TITLE
Various names of geometry field

### DIFF
--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -101,7 +101,7 @@ class FeatureHerald extends Herald {
 
     this.featureListener_ = new Listener(this.feature_.on('change', () => this.handleFeatureChange_()));
 
-    this.listener = new PropertyListener(this.feature_, null, this.feature_.geometryName_ ? this.feature_.geometryName_ : 'geometry', (geometry, oldGeometry) => {
+    this.listener = new PropertyListener(this.feature_, null, this.feature_.getGeometryName(), (geometry, oldGeometry) => {
       if (oldGeometry) {
         this.handleGeometryChange_();
       }

--- a/src/olgm/herald/Feature.js
+++ b/src/olgm/herald/Feature.js
@@ -101,7 +101,7 @@ class FeatureHerald extends Herald {
 
     this.featureListener_ = new Listener(this.feature_.on('change', () => this.handleFeatureChange_()));
 
-    this.listener = new PropertyListener(this.feature_, null, 'geometry', (geometry, oldGeometry) => {
+    this.listener = new PropertyListener(this.feature_, null, this.feature_.geometryName_ ? this.feature_.geometryName_ : 'geometry', (geometry, oldGeometry) => {
       if (oldGeometry) {
         this.handleGeometryChange_();
       }


### PR DESCRIPTION
Sometimes 'geometry' is not the name of the field that contains geometry object. In my case, I have WFS which has the geometry field named 'geom' and that name is located at field 'geometryName_'.