### PR TITLE
latest ol version have breaking changes in TileWMS.js

### DIFF
--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -123,7 +123,6 @@ class TileSourceHerald extends SourceHerald {
           this.handleVisibleChange_(cacheItem)
         )
       ),
-      new Listener(tileLayer.on('change', () => this.handleChange_(cacheItem))),
       new Listener(
         tileLayer.on('change:opacity', () =>
           this.handleOpacityChange_(cacheItem)
@@ -144,22 +143,6 @@ class TileSourceHerald extends SourceHerald {
     this.cache_.push(cacheItem);
   }
 
-  /**
-   * reset the googlemap layers
-   * @param {module:olgm/herald/TileSource~LayerCache} cacheItem cacheItem for the
-   * @private
-   */
-  handleChange_(cacheItem) {
-    const googleTileLayer = cacheItem.googleTileLayer;
-    const googleMapsLayers = this.gmap.overlayMapTypes;
-
-    // Get the position of the google layer so we can remove it
-    const layerIndex = googleMapsLayers.getArray().indexOf(googleTileLayer);
-    googleMapsLayers.removeAt(layerIndex);
-    this.deactivateCacheItem_(cacheItem);
-    googleMapsLayers.push(googleTileLayer);
-    this.activateCacheItem_(cacheItem);
-  }
   /**
    * This function is used by google maps to get the url for a tile at the given
    * coordinates and zoom level

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -30,15 +30,15 @@ class TileSourceHerald extends SourceHerald {
     super(ol3map, gmap);
 
     /**
-    * @type {Array<module:olgm/herald/TileSource~LayerCache>}
-    * @private
-    */
+     * @type {Array<module:olgm/herald/TileSource~LayerCache>}
+     * @private
+     */
     this.cache_ = [];
 
     /**
-    * @type {Array<module:ol/layer/Tile>}
-    * @private
-    */
+     * @type {Array<module:ol/layer/Tile>}
+     * @private
+     */
     this.layers_ = [];
 
     /**
@@ -53,11 +53,10 @@ class TileSourceHerald extends SourceHerald {
      * Accessing that pane means we can reorder the div for each tile layer
      * Google Maps is rendering.
      */
-    google.maps.event.addListenerOnce(gmap, 'idle', () => {
+    google.maps.event.addListenerOnce(gmap, "idle", () => {
       this.orderLayers();
     });
   }
-
 
   /**
    * @param {module:ol/layer/Base} layer layer to watch
@@ -73,7 +72,7 @@ class TileSourceHerald extends SourceHerald {
     }
 
     // If olgmWatch property is false then render using OL instead
-    if (tileLayer.get('olgmWatch') === false) {
+    if (tileLayer.get("olgmWatch") === false) {
       return;
     }
 
@@ -88,7 +87,7 @@ class TileSourceHerald extends SourceHerald {
       layer: tileLayer,
       listeners: [],
       opacity: opacity,
-      zIndex: 0
+      zIndex: 0,
     });
 
     const tileGrid = source.getTileGrid();
@@ -96,7 +95,7 @@ class TileSourceHerald extends SourceHerald {
 
     if (tileGrid) {
       const tileGridTileSize = tileGrid.getTileSize(0);
-      if (typeof tileGridTileSize === 'number') {
+      if (typeof tileGridTileSize === "number") {
         tileSize = tileGridTileSize;
       }
     }
@@ -104,10 +103,10 @@ class TileSourceHerald extends SourceHerald {
     const googleTileSize = new google.maps.Size(tileSize, tileSize);
 
     const options = {
-      'getTileUrl': this.googleGetTileUrlFunction_.bind(this, tileLayer),
-      'tileSize': googleTileSize,
-      'isPng': true,
-      'opacity': opacity
+      getTileUrl: this.googleGetTileUrlFunction_.bind(this, tileLayer),
+      tileSize: googleTileSize,
+      isPng: true,
+      opacity: opacity,
     };
 
     // Create the tiled layer on the google layer
@@ -119,13 +118,24 @@ class TileSourceHerald extends SourceHerald {
 
     cacheItem.listeners.push(
       // Hide the google layer when the ol3 layer is invisible
-      new Listener(tileLayer.on('change:visible', () => this.handleVisibleChange_(cacheItem))),
-      new Listener(tileLayer.on('change:opacity', () => this.handleOpacityChange_(cacheItem))),
-      new PropertyListener(tileLayer, null, 'source', (source, oldSource) => {
+      new Listener(
+        tileLayer.on("change:visible", () =>
+          this.handleVisibleChange_(cacheItem)
+        )
+      ),
+      new Listener(tileLayer.on("change", () => this.handleChange_(cacheItem))),
+      new Listener(
+        tileLayer.on("change:opacity", () =>
+          this.handleOpacityChange_(cacheItem)
+        )
+      ),
+      new PropertyListener(tileLayer, null, "source", (source, oldSource) => {
         if (oldSource) {
           this.handleSourceChange_(cacheItem);
         }
-        return new Listener(source.on('change', () => this.handleSourceChange_(cacheItem)));
+        return new Listener(
+          source.on("change", () => this.handleSourceChange_(cacheItem))
+        );
       })
     );
 
@@ -134,7 +144,25 @@ class TileSourceHerald extends SourceHerald {
     this.cache_.push(cacheItem);
   }
 
+  /**
+   * reset the googlemap layers
+   * @param {module:olgm/herald/TileSource~LayerCache} cacheItem cacheItem for the
+   * @private
+   */
+  handleChange_(cacheItem) {
+    const layer = cacheItem.layer;
+    const visible = layer.getVisible();
 
+    const googleTileLayer = cacheItem.googleTileLayer;
+    const googleMapsLayers = this.gmap.overlayMapTypes;
+
+    // Get the position of the google layer so we can remove it
+    const layerIndex = googleMapsLayers.getArray().indexOf(googleTileLayer);
+    googleMapsLayers.removeAt(layerIndex);
+    this.deactivateCacheItem_(cacheItem);
+    googleMapsLayers.push(googleTileLayer);
+    this.activateCacheItem_(cacheItem);
+  }
   /**
    * This function is used by google maps to get the url for a tile at the given
    * coordinates and zoom level
@@ -151,13 +179,16 @@ class TileSourceHerald extends SourceHerald {
     const minResolution = tileLayer.getMinResolution();
     const maxResolution = tileLayer.getMaxResolution();
     const currentResolution = this.ol3map.getView().getResolution();
-    if (currentResolution < minResolution || currentResolution > maxResolution) {
+    if (
+      currentResolution < minResolution ||
+      currentResolution > maxResolution
+    ) {
       return;
     }
 
     // Get a few variables from the source object
     let getTileUrlFunction = source.getTileUrlFunction();
-    const proj = get('EPSG:3857');
+    const proj = get("EPSG:3857");
 
     // Convert the coords from google maps to ol3 tile format
     const ol3Coords = [zoom, coords.x, coords.y];
@@ -169,19 +200,19 @@ class TileSourceHerald extends SourceHerald {
     }
 
     /* Perform some verifications only possible with a TileGrid:
-    * 1. If the origin for the layer isn't in the upper left corner, we need
-    *    to move the tiles there. Google Maps doesn't support custom origins.
-    * 2. Google Maps checks for tiles which might not exist, for example tiles
-    *    above the world map. We need to filter out these to avoid invalid
-    *    requests.
-    */
+     * 1. If the origin for the layer isn't in the upper left corner, we need
+     *    to move the tiles there. Google Maps doesn't support custom origins.
+     * 2. Google Maps checks for tiles which might not exist, for example tiles
+     *    above the world map. We need to filter out these to avoid invalid
+     *    requests.
+     */
     const tileGrid = source.getTileGrid();
     if (tileGrid) {
       /* Google maps always draws the tiles from the top left corner. We need to
-      * adjust for that if our origin isn't at that location
-      * The default origin is at the top left corner, and the default tile size
-      * is 256.
-      */
+       * adjust for that if our origin isn't at that location
+       * The default origin is at the top left corner, and the default tile size
+       * is 256.
+       */
       const defaultOrigin = [-20037508.342789244, 20037508.342789244];
       const defaultTileSize = 256;
       const origin = tileGrid.getOrigin(0);
@@ -189,17 +220,19 @@ class TileSourceHerald extends SourceHerald {
       // Skip this step if the origin is at the top left corner
       if (origin[0] != defaultOrigin[0] || origin[1] != defaultOrigin[1]) {
         /* Tiles have a size equal to 2^n. Find the difference between the n for
-        * the current tileGrid versus the n for the expected tileGrid.
-        */
-        const tileGridTileSize = /** @type {number} */ (tileGrid.getTileSize(zoom));
+         * the current tileGrid versus the n for the expected tileGrid.
+         */
+        const tileGridTileSize = /** @type {number} */ (tileGrid.getTileSize(
+          zoom
+        ));
 
         const defaultTileSizeExponent = Math.log2(defaultTileSize);
         const tileSizeExponent = Math.log2(tileGridTileSize);
         const exponentDifference = tileSizeExponent - defaultTileSizeExponent;
 
         /* Calculate the offset to add to the tile coordinates, assuming the
-        * origin to fix is equal to [0, 0]. TODO: Support different origins
-        */
+         * origin to fix is equal to [0, 0]. TODO: Support different origins
+         */
         const nbTilesSide = Math.pow(2, zoom - exponentDifference);
         const offset = nbTilesSide / 2;
 
@@ -209,13 +242,15 @@ class TileSourceHerald extends SourceHerald {
       }
 
       /* Get the intersection area between the wanted tile's extent and the
-      * layer's extent. If that intersection has an area smaller than 1, it
-      * means it's not part of the map. We do this because a tile directly
-      * above the map but not inside it still counts as an intersection, but
-      * with a size of 0.
-      */
+       * layer's extent. If that intersection has an area smaller than 1, it
+       * means it's not part of the map. We do this because a tile directly
+       * above the map but not inside it still counts as an intersection, but
+       * with a size of 0.
+       */
       const intersection = getIntersection(
-        extent, tileGrid.getTileCoordExtent(ol3Coords));
+        extent,
+        tileGrid.getTileCoordExtent(ol3Coords)
+      );
       const intersectionSize = getSize(intersection);
       const intersectionArea = intersectionSize[0] * intersectionSize[1];
 
@@ -235,7 +270,6 @@ class TileSourceHerald extends SourceHerald {
     return result;
   }
 
-
   /**
    * Unwatch the tile layer
    * @param {module:ol/layer/Base} layer layer to unwatch
@@ -249,7 +283,7 @@ class TileSourceHerald extends SourceHerald {
       this.layers_.splice(index, 1);
 
       const cacheItem = this.cache_[index];
-      cacheItem.listeners.forEach(listener => listener.unlisten());
+      cacheItem.listeners.forEach((listener) => listener.unlisten());
 
       // Remove the layer from google maps
       const googleTileLayer = cacheItem.googleTileLayer;
@@ -268,7 +302,6 @@ class TileSourceHerald extends SourceHerald {
     }
   }
 
-
   /**
    * Activate all cache items
    * @api
@@ -278,7 +311,6 @@ class TileSourceHerald extends SourceHerald {
     super.activate();
     this.cache_.forEach(this.activateCacheItem_, this);
   }
-
 
   /**
    * Activates an tile layer cache item.
@@ -294,7 +326,6 @@ class TileSourceHerald extends SourceHerald {
     }
   }
 
-
   /**
    * Deactivate all cache items
    * @api
@@ -305,7 +336,6 @@ class TileSourceHerald extends SourceHerald {
     this.cache_.forEach(this.deactivateCacheItem_, this);
   }
 
-
   /**
    * Deactivates a Tile layer cache item.
    * @param {module:olgm/herald/TileSource~LayerCache} cacheItem cacheItem to deactivate
@@ -315,7 +345,6 @@ class TileSourceHerald extends SourceHerald {
     cacheItem.ignoreNextOpacityChange = true;
     cacheItem.layer.setOpacity(cacheItem.opacity);
   }
-
 
   /**
    * This function finds the div associated to each tile layer we watch, then
@@ -361,15 +390,17 @@ class TileSourceHerald extends SourceHerald {
           if (childNodes.indexOf(childNodesWithLayer[j]) == -1) {
             // Set a timeout because otherwise it won't work
             cacheItem.element = childNodesWithLayer[j];
-            setTimeout(function() {
-              this.element.style.zIndex = this.zIndex;
-            }.bind(cacheItem), 0);
+            setTimeout(
+              function () {
+                this.element.style.zIndex = this.zIndex;
+              }.bind(cacheItem),
+              0
+            );
           }
         }
       }
     }
   }
-
 
   /**
    * Handle the opacity being changed on the tile layer
@@ -390,7 +421,6 @@ class TileSourceHerald extends SourceHerald {
     if (cacheItem.ignoreNextOpacityChange) {
       cacheItem.ignoreNextOpacityChange = false;
     } else {
-
       cacheItem.googleTileLayer.setOpacity(newOpacity);
       cacheItem.opacity = newOpacity;
 
@@ -433,7 +463,6 @@ class TileSourceHerald extends SourceHerald {
     }
   }
 
-
   /**
    * Called the source of layer fires the 'change' event. Reload the google tile
    * layer.
@@ -445,7 +474,7 @@ class TileSourceHerald extends SourceHerald {
   handleSourceChange_(cacheItem) {
     // Note: The 'changed' method of google.maps.MVCObject requires a param,
     //       but it's not acutally used here.  It's just to satisfy the compiler.
-    cacheItem.googleTileLayer.changed('foo');
+    cacheItem.googleTileLayer.changed("foo");
   }
 }
 

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -224,7 +224,7 @@ class TileSourceHerald extends SourceHerald {
       }
     }
 
-    let result = getTileUrlFunction(ol3Coords, 1, proj);
+    let result = source.tileUrlFunction(ol3Coords, 1, proj);
 
     // TileJSON sources don't have their url function right away, try again
     if (result === undefined) {

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -186,8 +186,6 @@ class TileSourceHerald extends SourceHerald {
       return;
     }
 
-    // Get a few variables from the source object
-    let getTileUrlFunction = source.getTileUrlFunction();
     const proj = get("EPSG:3857");
 
     // Convert the coords from google maps to ol3 tile format
@@ -263,7 +261,7 @@ class TileSourceHerald extends SourceHerald {
 
     // TileJSON sources don't have their url function right away, try again
     if (result === undefined) {
-      getTileUrlFunction = source.getTileUrlFunction();
+      let getTileUrlFunction = source.getTileUrlFunction();
       result = getTileUrlFunction(ol3Coords, 1, proj);
     }
 

--- a/src/olgm/herald/TileSource.js
+++ b/src/olgm/herald/TileSource.js
@@ -53,7 +53,7 @@ class TileSourceHerald extends SourceHerald {
      * Accessing that pane means we can reorder the div for each tile layer
      * Google Maps is rendering.
      */
-    google.maps.event.addListenerOnce(gmap, "idle", () => {
+    google.maps.event.addListenerOnce(gmap, 'idle', () => {
       this.orderLayers();
     });
   }
@@ -72,7 +72,7 @@ class TileSourceHerald extends SourceHerald {
     }
 
     // If olgmWatch property is false then render using OL instead
-    if (tileLayer.get("olgmWatch") === false) {
+    if (tileLayer.get('olgmWatch') === false) {
       return;
     }
 
@@ -87,7 +87,7 @@ class TileSourceHerald extends SourceHerald {
       layer: tileLayer,
       listeners: [],
       opacity: opacity,
-      zIndex: 0,
+      zIndex: 0
     });
 
     const tileGrid = source.getTileGrid();
@@ -95,7 +95,7 @@ class TileSourceHerald extends SourceHerald {
 
     if (tileGrid) {
       const tileGridTileSize = tileGrid.getTileSize(0);
-      if (typeof tileGridTileSize === "number") {
+      if (typeof tileGridTileSize === 'number') {
         tileSize = tileGridTileSize;
       }
     }
@@ -106,7 +106,7 @@ class TileSourceHerald extends SourceHerald {
       getTileUrl: this.googleGetTileUrlFunction_.bind(this, tileLayer),
       tileSize: googleTileSize,
       isPng: true,
-      opacity: opacity,
+      opacity: opacity
     };
 
     // Create the tiled layer on the google layer
@@ -119,22 +119,22 @@ class TileSourceHerald extends SourceHerald {
     cacheItem.listeners.push(
       // Hide the google layer when the ol3 layer is invisible
       new Listener(
-        tileLayer.on("change:visible", () =>
+        tileLayer.on('change:visible', () =>
           this.handleVisibleChange_(cacheItem)
         )
       ),
-      new Listener(tileLayer.on("change", () => this.handleChange_(cacheItem))),
+      new Listener(tileLayer.on('change', () => this.handleChange_(cacheItem))),
       new Listener(
-        tileLayer.on("change:opacity", () =>
+        tileLayer.on('change:opacity', () =>
           this.handleOpacityChange_(cacheItem)
         )
       ),
-      new PropertyListener(tileLayer, null, "source", (source, oldSource) => {
+      new PropertyListener(tileLayer, null, 'source', (source, oldSource) => {
         if (oldSource) {
           this.handleSourceChange_(cacheItem);
         }
         return new Listener(
-          source.on("change", () => this.handleSourceChange_(cacheItem))
+          source.on('change', () => this.handleSourceChange_(cacheItem))
         );
       })
     );
@@ -150,9 +150,6 @@ class TileSourceHerald extends SourceHerald {
    * @private
    */
   handleChange_(cacheItem) {
-    const layer = cacheItem.layer;
-    const visible = layer.getVisible();
-
     const googleTileLayer = cacheItem.googleTileLayer;
     const googleMapsLayers = this.gmap.overlayMapTypes;
 
@@ -186,7 +183,7 @@ class TileSourceHerald extends SourceHerald {
       return;
     }
 
-    const proj = get("EPSG:3857");
+    const proj = get('EPSG:3857');
 
     // Convert the coords from google maps to ol3 tile format
     const ol3Coords = [zoom, coords.x, coords.y];
@@ -261,7 +258,7 @@ class TileSourceHerald extends SourceHerald {
 
     // TileJSON sources don't have their url function right away, try again
     if (result === undefined) {
-      let getTileUrlFunction = source.getTileUrlFunction();
+      const getTileUrlFunction = source.getTileUrlFunction();
       result = getTileUrlFunction(ol3Coords, 1, proj);
     }
 
@@ -388,12 +385,9 @@ class TileSourceHerald extends SourceHerald {
           if (childNodes.indexOf(childNodesWithLayer[j]) == -1) {
             // Set a timeout because otherwise it won't work
             cacheItem.element = childNodesWithLayer[j];
-            setTimeout(
-              function () {
-                this.element.style.zIndex = this.zIndex;
-              }.bind(cacheItem),
-              0
-            );
+            setTimeout(function() {
+              this.element.style.zIndex = this.zIndex;
+            }.bind(cacheItem), 0);
           }
         }
       }
@@ -472,7 +466,7 @@ class TileSourceHerald extends SourceHerald {
   handleSourceChange_(cacheItem) {
     // Note: The 'changed' method of google.maps.MVCObject requires a param,
     //       but it's not acutally used here.  It's just to satisfy the compiler.
-    cacheItem.googleTileLayer.changed("foo");
+    cacheItem.googleTileLayer.changed('foo');
   }
 }
 


### PR DESCRIPTION
latest ol version have breaking changes in TileWMS.js which has moved tileUrlFunction inside the class and not passing in constructor any more, hence in olgm TileSource.js getSource to TileImage will not have reference to tileUrlFunction (its optional).

Below link is the ol change on  TileWMS.js
https://github.com/openlayers/openlayers/commit/29ce0bb223aea7916243f86c05a9b1b5821d943d